### PR TITLE
Add Cursor Cloud dev environment setup (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`tsk.lol` is an npm-workspace monorepo. The only real product is the web app at
+`apps/web` (a Vite + React + TypeScript app). `apps/mobile`, `apps/desktop`, and
+`packages/shared` are empty placeholders with no runnable code, so all
+lint/test/build/run work targets `@tsk/web`.
+
+### Commands
+
+Standard commands are defined in the root `package.json` (they proxy to the
+`@tsk/web` workspace). Run them from the repo root:
+
+- `npm run dev` — start the Vite dev server (defaults to `http://localhost:5173/`).
+- `npm run lint` — ESLint (runs with `--max-warnings 0`, so any warning fails).
+- `npm run test` — Vitest unit tests.
+- `npm run build` — type-check (`tsc`) then production Vite build.
+
+Dependencies are installed with `npm install` from the repo root (single root
+lockfile for the whole workspace).
+
+### Non-obvious notes
+
+- Data/auth/sync is backed by the hosted [Basic.tech](https://basic.tech) service
+  (`@basictech/react`, project config in `apps/web/basic.config.ts`). There is no
+  local backend to run — the dev server alone is enough to exercise the app.
+- The app is **local-first**: you can create/edit tasks, folders, and schedule
+  items without signing in. Tasks persist locally and survive reloads, so a
+  Basic.tech account is NOT required to test core functionality. Sign-in only
+  matters for cross-device cloud sync.
+- On a cold first load there is a brief DB-readiness race: writes are gated on a
+  readiness hook (`apps/web/src/hooks/useBasicDbReady.ts`) and a task created in
+  the very first moment may not render until the local DB reaches a ready
+  `sync.status`. If a just-created task doesn't appear, wait for the app to
+  finish its initial load (or reload once) and retry — this is expected startup
+  behavior, not a bug.
+- The production build emits a large (~1 MB) main JS chunk and a chunk-size
+  warning; this is known/expected and does not indicate a broken build.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the Cloud Agent development environment for `tsk.lol` and documents it for future agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the monorepo layout, standard commands, and non-obvious runtime caveats (local-first Basic.tech data, cold-start DB-readiness race, expected large bundle warning).
- Update script for the environment is `npm install` (single root lockfile for the whole workspace).

No application code was changed.

## Verification

All commands run from the repo root:

| Step | Command | Result |
| --- | --- | --- |
| Install | `npm install` | 696 packages installed |
| Lint | `npm run lint` | Passed (0 warnings) |
| Test | `npm run test` | 7 tests passed (2 files) |
| Build | `npm run build` | Built successfully (`dist/`) |
| Run | `npm run dev` | Dev server on `http://localhost:5173/` |

### Hello-world task

Created a task in the running app (local-first, no sign-in required); it appears in the task list and persists across reloads.

[tsk_create_task_working_demo.mp4](https://cursor.com/agents/bc-4ba47995-8fbc-4511-a8c3-7b54551f5b4d/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Ftsk_create_task_working_demo.mp4)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ba47995-8fbc-4511-a8c3-7b54551f5b4d?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ba47995-8fbc-4511-a8c3-7b54551f5b4d&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

