### PR TITLE
Upgrade Basic SDK to 0.11.0-beta.1

### DIFF
--- a/apps/web/basic.config.ts
+++ b/apps/web/basic.config.ts
@@ -1,95 +1,96 @@
+import { defineSchema } from "@basictech/schema/define";
 
 // Basic Project Configuration
-// see  the docs for more info: https://docs.basic.tech
+// see the docs for more info: https://docs.basic.tech
 export const config = {
 	name: "tsk.lol",
-	project_id: "701b11bc-59a8-45b5-8148-7184d7733e5b"
+	project_id: "701b11bc-59a8-45b5-8148-7184d7733e5b",
 };
 
-export const schema = {
-	"tables": {
-		"tasks": {
-			"name": "tasks",
-			"type": "collection",
-			"fields": {
-				"name": {
-					"type": "string"
+export const schema = defineSchema({
+	project_id: "701b11bc-59a8-45b5-8148-7184d7733e5b",
+	version: 6,
+	tables: {
+		tasks: {
+			name: "tasks",
+			type: "collection",
+			fields: {
+				name: {
+					type: "string",
 				},
-				"labels": {
-					"type": "string",
-					"indexed": true
+				labels: {
+					type: "string",
+					indexed: true,
 				},
-				"completed": {
-					"type": "boolean"
+				completed: {
+					type: "boolean",
 				},
-				"description": {
-					"type": "string"
+				description: {
+					type: "string",
 				},
-				"parentTaskId": {
-					"type": "string",
-					"indexed": true
-				}
-			}
+				parentTaskId: {
+					type: "string",
+					indexed: true,
+				},
+			},
 		},
-		"filters": {
-			"type": "collection",
-			"fields": {
-				"name": {
-					"type": "string",
-					"indexed": true
+		filters: {
+			type: "collection",
+			fields: {
+				name: {
+					type: "string",
+					indexed: true,
 				},
-				"labels": {
-					"type": "string",
-					"indexed": true
-				}, 
-				"color": {
-					"type": "string",
-					"indexed": true
-				  },
-				  "icon": {
-					"type": "string",
-					"indexed": true
-				  }
-			}
+				labels: {
+					type: "string",
+					indexed: true,
+				},
+				color: {
+					type: "string",
+					indexed: true,
+				},
+				icon: {
+					type: "string",
+					indexed: true,
+				},
+			},
 		},
-		"schedule": {
-			"type": "collection",
-			"fields": {
-				"end": {
-					"type": "json",
-					"indexed": true
+		schedule: {
+			type: "collection",
+			fields: {
+				end: {
+					type: "json",
+					indexed: true,
 				},
-				"type": {
-					"type": "string",
-					"indexed": true
+				type: {
+					type: "string",
+					indexed: true,
 				},
-				"color": {
-					"type": "string",
-					"indexed": true
+				color: {
+					type: "string",
+					indexed: true,
 				},
-				"start": {
-					"type": "json",
-					"indexed": true
+				start: {
+					type: "json",
+					indexed: true,
 				},
-				"title": {
-					"type": "string",
-					"indexed": true
+				title: {
+					type: "string",
+					indexed: true,
 				},
-				"taskId": {
-					"type": "string",
-					"indexed": true
+				taskId: {
+					type: "string",
+					indexed: true,
 				},
-				"description": {
-					"type": "string",
-					"indexed": true
+				description: {
+					type: "string",
+					indexed: true,
 				},
-				"metadata": {
-					"type": "json",
-					"indexed": true
-				}
-			}
-		}
+				metadata: {
+					type: "json",
+					indexed: true,
+				},
+			},
+		},
 	},
-	"version": 6,
-	"project_id": "701b11bc-59a8-45b5-8148-7184d7733e5b"
-}
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@basictech/react": "0.9.0-beta.1",
+    "@basictech/react": "0.11.0-beta.1",
+    "@basictech/schema": "0.11.0-beta.1",
     "@radix-ui/react-popover": "^1.1.19",
     "@radix-ui/react-switch": "^1.3.3",
     "@silk-hq/components": "^0.8.15",

--- a/apps/web/public/.well-known/basic-app.json
+++ b/apps/web/public/.well-known/basic-app.json
@@ -1,0 +1,21 @@
+{
+  "client_id": "did:web:tsk.lol",
+  "client_name": "tsk",
+  "application_type": "web",
+  "token_endpoint_auth_method": "none",
+  "grant_types": [
+    "authorization_code",
+    "refresh_token"
+  ],
+  "response_types": [
+    "code"
+  ],
+  "redirect_uris": [
+    "https://tsk.lol/",
+    "https://tsk.lol",
+    "http://localhost:5173/",
+    "http://localhost:5173",
+    "http://127.0.0.1:5173/",
+    "http://127.0.0.1:5173"
+  ]
+}

--- a/apps/web/public/.well-known/did.json
+++ b/apps/web/public/.well-known/did.json
@@ -1,0 +1,13 @@
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1"
+  ],
+  "id": "did:web:tsk.lol",
+  "service": [
+    {
+      "id": "#basic_app",
+      "type": "BasicAppMetadata",
+      "serviceEndpoint": "https://tsk.lol/.well-known/basic-app.json"
+    }
+  ]
+}

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,5 +1,4 @@
-import { useBasic, useQuery } from "@basictech/react";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import bgImage from "/bg2.jpg";
 import "./App.css";
 import AboutModal from "./components/AboutModal";
@@ -18,41 +17,23 @@ import SilkTaskDrawer from "./components/SilkTaskDrawer";
 import UserAvatarButton from "./components/UserAvatarButton";
 import { ThemeProvider, useTheme } from "./contexts/ThemeContext";
 import { useAppActions } from "./hooks/useAppActions";
-import { readBasicDbSafely, useBasicDbReady } from "./hooks/useBasicDbReady";
+import { useFolderRecords, useScheduleRecords, useTaskRecords } from "./hooks/useBasicData";
+import { useBasicDbReady } from "./hooks/useBasicDbReady";
 import { useHomeKeyboardShortcuts } from "./hooks/useHomeKeyboardShortcuts";
 import { useHomeUiState } from "./hooks/useHomeUiState";
 import { useTaskCollections } from "./hooks/useTaskCollections";
 import { ScheduleCardData } from "./utils/schedule";
-import { Folder, Task } from "./utils/types";
+import { Task } from "./utils/types";
 
 function Home() {
-  const { db } = useBasic();
   const isDbReady = useBasicDbReady();
   const { theme } = useTheme();
 
-  const tasksData = useQuery(
-    () => readBasicDbSafely(isDbReady, () => db.table<Task>("tasks").getAll(), Promise.resolve([] as Task[])),
-    [isDbReady],
-  );
-  const scheduleEventsData = useQuery(
-    () => readBasicDbSafely(
-      isDbReady,
-      () => db.table<ScheduleCardData>("schedule").getAll(),
-      Promise.resolve([] as ScheduleCardData[]),
-    ),
-    [isDbReady],
-  );
-  const foldersData = useQuery(
-    () => readBasicDbSafely(isDbReady, () => db.table<Folder>("filters").getAll(), Promise.resolve([] as Folder[])),
-    [isDbReady],
-  );
+  const { tasks, isLoading: tasksLoading } = useTaskRecords();
+  const { events: scheduleEvents, isLoading: scheduleLoading } = useScheduleRecords();
+  const { folders, isLoading: foldersLoading } = useFolderRecords();
 
-  const isCollectionsLoading =
-    !isDbReady || tasksData === undefined || scheduleEventsData === undefined || foldersData === undefined;
-
-  const tasks = useMemo(() => (tasksData ?? []) as Task[], [tasksData]);
-  const scheduleEvents = useMemo(() => (scheduleEventsData ?? []) as ScheduleCardData[], [scheduleEventsData]);
-  const folders = useMemo(() => (foldersData ?? []) as Folder[], [foldersData]);
+  const isCollectionsLoading = !isDbReady || tasksLoading || scheduleLoading || foldersLoading;
   const [showDelayedLoadingState, setShowDelayedLoadingState] = useState(false);
 
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);

--- a/apps/web/src/basic.ts
+++ b/apps/web/src/basic.ts
@@ -1,10 +1,10 @@
 import { createBasic } from "@basictech/react";
 import { schema } from "../basic.config";
+import { rewriteBasicDevUrl } from "./basicDevProxy";
 
 export { schema };
 
 const DEFAULT_CLIENT_ID = "did:web:tsk.lol";
-const PUBLISHED_WELL_KNOWN_ORIGIN = "https://tsk.lol";
 
 function createBasicFetch(): typeof fetch {
   const browserFetch = globalThis.fetch.bind(globalThis);
@@ -19,12 +19,29 @@ function createBasicFetch(): typeof fetch {
       : input instanceof URL
         ? input.toString()
         : input.url;
+    const rewritten = rewriteBasicDevUrl(url, window.location.origin);
 
-    if (url.startsWith(`${PUBLISHED_WELL_KNOWN_ORIGIN}/.well-known/`)) {
-      return browserFetch(url.replace(PUBLISHED_WELL_KNOWN_ORIGIN, window.location.origin), init);
+    if (rewritten === url) {
+      return browserFetch(input, init);
     }
 
-    return browserFetch(input, init);
+    if (input instanceof Request) {
+      return browserFetch(new Request(rewritten, input), init);
+    }
+
+    return browserFetch(rewritten, init);
+  };
+}
+
+function createBasicWebSocket() {
+  if (!import.meta.env.DEV || typeof window === "undefined") {
+    return undefined;
+  }
+
+  return class BasicDevWebSocket extends WebSocket {
+    constructor(url: string | URL, protocols?: string | string[]) {
+      super(rewriteBasicDevUrl(url.toString(), window.location.origin), protocols);
+    }
   };
 }
 
@@ -34,4 +51,5 @@ export const basic = createBasic({
   debug: import.meta.env.DEV,
   allowInsecure: import.meta.env.DEV,
   fetch: createBasicFetch(),
+  WebSocketImpl: createBasicWebSocket(),
 });

--- a/apps/web/src/basic.ts
+++ b/apps/web/src/basic.ts
@@ -1,0 +1,12 @@
+import { createBasic } from "@basictech/react";
+import { schema } from "../basic.config";
+
+export { schema };
+
+const DEFAULT_CLIENT_ID = "did:web:tsk.lol";
+
+export const basic = createBasic({
+  schema,
+  clientId: import.meta.env.VITE_BASIC_CLIENT_ID || DEFAULT_CLIENT_ID,
+  debug: import.meta.env.DEV,
+});

--- a/apps/web/src/basic.ts
+++ b/apps/web/src/basic.ts
@@ -4,9 +4,34 @@ import { schema } from "../basic.config";
 export { schema };
 
 const DEFAULT_CLIENT_ID = "did:web:tsk.lol";
+const PUBLISHED_WELL_KNOWN_ORIGIN = "https://tsk.lol";
+
+function createBasicFetch(): typeof fetch {
+  const browserFetch = globalThis.fetch.bind(globalThis);
+
+  if (!import.meta.env.DEV || typeof window === "undefined") {
+    return browserFetch;
+  }
+
+  return (input, init) => {
+    const url = typeof input === "string"
+      ? input
+      : input instanceof URL
+        ? input.toString()
+        : input.url;
+
+    if (url.startsWith(`${PUBLISHED_WELL_KNOWN_ORIGIN}/.well-known/`)) {
+      return browserFetch(url.replace(PUBLISHED_WELL_KNOWN_ORIGIN, window.location.origin), init);
+    }
+
+    return browserFetch(input, init);
+  };
+}
 
 export const basic = createBasic({
   schema,
   clientId: import.meta.env.VITE_BASIC_CLIENT_ID || DEFAULT_CLIENT_ID,
   debug: import.meta.env.DEV,
+  allowInsecure: import.meta.env.DEV,
+  fetch: createBasicFetch(),
 });

--- a/apps/web/src/basicDevProxy.test.ts
+++ b/apps/web/src/basicDevProxy.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "vitest";
+import {
+  basicPdsProxyTarget,
+  rewriteBasicDevUrl,
+  shouldProxyBasicHost,
+  stripBasicPdsProxyPrefix,
+} from "./basicDevProxy";
+
+describe("basicDevProxy", () => {
+  it("rewrites published DID documents to the local origin", () => {
+    expect(
+      rewriteBasicDevUrl("https://tsk.lol/.well-known/did.json", "http://localhost:5173"),
+    ).toBe("http://localhost:5173/.well-known/did.json");
+  });
+
+  it("proxies PDS HTTP and WebSocket URLs through Vite", () => {
+    expect(
+      rewriteBasicDevUrl("https://pds.basic.id/api/v1/account/repos", "http://localhost:5173"),
+    ).toBe("http://localhost:5173/__basic-pds/pds.basic.id/api/v1/account/repos");
+
+    expect(
+      rewriteBasicDevUrl("wss://pds.basic.id/sync/", "http://localhost:5173"),
+    ).toBe("ws://localhost:5173/__basic-pds/pds.basic.id/sync/");
+  });
+
+  it("leaves the identity origin and relative URLs alone", () => {
+    expect(shouldProxyBasicHost("basic.id")).toBe(false);
+    expect(rewriteBasicDevUrl("https://basic.id/authorize", "http://localhost:5173")).toBe(
+      "https://basic.id/authorize",
+    );
+    expect(rewriteBasicDevUrl("/local", "http://localhost:5173")).toBe("/local");
+  });
+
+  it("maps proxied paths back to the PDS origin", () => {
+    expect(basicPdsProxyTarget("/__basic-pds/pds.basic.id/api/v1/account/repos")).toBe(
+      "https://pds.basic.id",
+    );
+    expect(stripBasicPdsProxyPrefix("/__basic-pds/pds.basic.id/api/v1/account/repos")).toBe(
+      "/api/v1/account/repos",
+    );
+  });
+});

--- a/apps/web/src/basicDevProxy.ts
+++ b/apps/web/src/basicDevProxy.ts
@@ -1,0 +1,47 @@
+export const PUBLISHED_WELL_KNOWN_ORIGIN = "https://tsk.lol";
+export const BASIC_PDS_PROXY_PREFIX = "/__basic-pds";
+
+export function shouldProxyBasicHost(hostname: string) {
+  if (hostname === "basic.id" || hostname === "www.basic.id") {
+    return false;
+  }
+
+  return hostname === "pds.basic.id" || hostname.endsWith(".basic.id");
+}
+
+export function rewriteBasicDevUrl(url: string, origin: string) {
+  if (url.startsWith(`${PUBLISHED_WELL_KNOWN_ORIGIN}/.well-known/`)) {
+    return `${origin}${url.slice(PUBLISHED_WELL_KNOWN_ORIGIN.length)}`;
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return url;
+  }
+
+  if (!shouldProxyBasicHost(parsed.hostname)) {
+    return url;
+  }
+
+  const proxied = new URL(origin);
+  proxied.pathname = `${BASIC_PDS_PROXY_PREFIX}/${parsed.host}${parsed.pathname}`;
+  proxied.search = parsed.search;
+  proxied.hash = parsed.hash;
+  if (parsed.protocol === "ws:" || parsed.protocol === "wss:") {
+    proxied.protocol = origin.startsWith("https:") ? "wss:" : "ws:";
+  }
+
+  return proxied.toString();
+}
+
+export function basicPdsProxyTarget(requestUrl: string) {
+  const path = requestUrl.startsWith("http") ? new URL(requestUrl).pathname : requestUrl;
+  const match = path.match(/^\/__basic-pds\/([^/?#]+)/);
+  return match ? `https://${match[1]}` : "https://pds.basic.id";
+}
+
+export function stripBasicPdsProxyPrefix(path: string) {
+  return path.replace(/^\/__basic-pds\/[^/]+/, "") || "/";
+}

--- a/apps/web/src/components/AgendaView.tsx
+++ b/apps/web/src/components/AgendaView.tsx
@@ -1,8 +1,7 @@
 import React, { useMemo, useState } from 'react';
 import { ScheduleCardData } from '../utils/schedule';
-import { useBasic, useQuery } from '@basictech/react';
-import { readBasicDbSafely, useBasicDbReady } from '../hooks/useBasicDbReady';
-import { Folder, Task } from '../utils/types';
+import { useTaskRecord, useTaskRecords } from '../hooks/useBasicData';
+import { Folder } from '../utils/types';
 import { 
   isToday, 
   getStartOfDay, 
@@ -92,18 +91,7 @@ const ScheduleItemRow: React.FC<ScheduleItemRowProps> = ({
   isDarkMode,
   onCardClick,
 }) => {
-  const { db } = useBasic();
-  const isDbReady = useBasicDbReady();
-  
-  // Fetch linked task if this is a task event
-  const linkedTask = useQuery(
-    () => readBasicDbSafely(
-      isDbReady,
-      () => event.taskId && event.taskId !== '' ? db.table<Task>('tasks').get(event.taskId) : Promise.resolve(null),
-      Promise.resolve(null),
-    ),
-    [isDbReady, event.taskId]
-  );
+  const linkedTask = useTaskRecord(event.taskId && event.taskId !== '' ? event.taskId : null);
   
   const isTask = event.type === 'task';
   const isCompleted = isTask && linkedTask?.completed;
@@ -238,14 +226,7 @@ const RadialProgress: React.FC<{
 };
 
 const TaskProgress: React.FC<TaskProgressProps> = ({ taskIds, isDarkMode }) => {
-  const { db } = useBasic();
-  const isDbReady = useBasicDbReady();
-  
-  // Fetch all tasks
-  const allTasks = useQuery(
-    () => readBasicDbSafely(isDbReady, () => db.table<Task>('tasks').getAll(), Promise.resolve([] as Task[])),
-    [isDbReady],
-  );
+  const { tasks: allTasks } = useTaskRecords();
   
   // Compute stats
   const stats = useMemo(() => {
@@ -253,7 +234,7 @@ const TaskProgress: React.FC<TaskProgressProps> = ({ taskIds, isDarkMode }) => {
       return { total: 0, completed: 0 };
     }
     
-    const scheduledTasks = (allTasks as Task[]).filter((task) => taskIds.includes(task.id));
+    const scheduledTasks = allTasks.filter((task) => taskIds.includes(task.id));
     const completedCount = scheduledTasks.filter((task) => task.completed).length;
     
     return {
@@ -299,19 +280,14 @@ interface TaskCountSummaryProps {
 }
 
 const TaskCountSummary: React.FC<TaskCountSummaryProps> = ({ taskIds, eventCount }) => {
-  const { db } = useBasic();
-  const isDbReady = useBasicDbReady();
-  const allTasks = useQuery(
-    () => readBasicDbSafely(isDbReady, () => db.table<Task>('tasks').getAll(), Promise.resolve([] as Task[])),
-    [isDbReady],
-  );
+  const { tasks: allTasks } = useTaskRecords();
   
   const stats = useMemo(() => {
     if (!allTasks || taskIds.length === 0) {
       return { total: 0, completed: 0, pending: 0 };
     }
     
-    const scheduledTasks = (allTasks as Task[]).filter((task) => taskIds.includes(task.id));
+    const scheduledTasks = allTasks.filter((task) => taskIds.includes(task.id));
     const completedCount = scheduledTasks.filter((task) => task.completed).length;
     
     return {

--- a/apps/web/src/components/DynamicIsland.tsx
+++ b/apps/web/src/components/DynamicIsland.tsx
@@ -3,9 +3,8 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { Folder, Task, TaskUpdate } from '../utils/types';
 import { ScheduleCardData, ScheduleCardInput, ScheduleCardUpdate, getEventDuration, getTimeFromDateTime } from '../utils/schedule';
 import Checkbox from './Checkbox';
-import { useBasic, useQuery } from '@basictech/react';
 import { useTheme } from '../contexts/ThemeContext';
-import { readBasicDbSafely, useBasicDbReady } from '../hooks/useBasicDbReady';
+import { useScheduleRecord, useScheduleRecords, useSubtaskRecords, useTaskRecord } from '../hooks/useBasicData';
 import SubtasksList from './SubtasksList';
 import { useAutoResizeTextarea } from '../hooks/useAutoResizeTextarea';
 
@@ -114,43 +113,12 @@ const DynamicIsland: React.FC<DynamicIslandProps> = ({
   const isEventView = selectedEvent !== null;
   
   // Fetch scheduled events for the selected task
-  const { db } = useBasic();
-  const isDbReady = useBasicDbReady();
-  
-  // Fetch live task data from database (like ScheduleCard does)
-  const liveTask = useQuery(
-    () => readBasicDbSafely(
-      isDbReady,
-      () => selectedTask?.id ? db.table<Task>('tasks').get(selectedTask.id) : Promise.resolve(null),
-      Promise.resolve(null),
-    ),
-    [isDbReady, selectedTask?.id]
-  );
-  
-  // Fetch live event data from database (same pattern as tasks)
-  const liveEvent = useQuery(
-    () => readBasicDbSafely(
-      isDbReady,
-      () => selectedEvent?.id ? db.table<ScheduleCardData>('schedule').get(selectedEvent.id) : Promise.resolve(null),
-      Promise.resolve(null),
-    ),
-    [isDbReady, selectedEvent?.id]
-  );
-  
-  // Use live data if available, otherwise fall back to props
+  const liveTask = useTaskRecord(selectedTask?.id);
+  const liveEvent = useScheduleRecord(selectedEvent?.id);
   const currentTask = liveTask || selectedTask;
   const currentEvent = liveEvent || selectedEvent;
-  
-  const scheduledEvents = useQuery(
-    () => readBasicDbSafely(
-      isDbReady,
-      () => selectedTask?.id
-        ? db.table<ScheduleCardData>('schedule').find((event) => event.taskId === selectedTask.id)
-        : Promise.resolve(null),
-      Promise.resolve(null),
-    ),
-    [isDbReady, selectedTask?.id]
-  ) as ScheduleCardData[] | null;
+  const { events: scheduledEventsForTask } = useScheduleRecords(selectedTask?.id);
+  const scheduledEvents = selectedTask?.id ? scheduledEventsForTask : null;
 
   // Check if task has any scheduled events for today
   const hasScheduledEventToday = (() => {
@@ -179,30 +147,15 @@ const DynamicIsland: React.FC<DynamicIslandProps> = ({
   })();
 
   // Query subtasks for deleted task (if viewing a deleted task schedule item)
-  const deletedTaskSubtasks = useQuery(
-    () => readBasicDbSafely(
-      isDbReady,
-      () => selectedEvent?.type === 'task' &&
-            (!selectedEvent?.taskId || selectedEvent?.taskId === '') &&
-            selectedEvent?.metadata?.taskSnapshot?.id
-        ? db.table<Task>('tasks').find((task) => task.parentTaskId === selectedEvent.metadata?.taskSnapshot?.id)
-        : Promise.resolve(null),
-      Promise.resolve(null),
-    ),
-    [isDbReady, selectedEvent?.metadata?.taskSnapshot?.id]
-  ) as Task[] | null;
-
-  // Query subtasks for the selected task
-  const subtasks = (useQuery(
-    () => readBasicDbSafely(
-      isDbReady,
-      () => selectedTask?.id && !selectedTask?.parentTaskId
-        ? db.table<Task>('tasks').find((t) => t.parentTaskId === selectedTask.id)
-        : Promise.resolve(null),
-      Promise.resolve(null),
-    ),
-    [isDbReady, selectedTask?.id, selectedTask?.parentTaskId]
-  ) || []) as Task[];
+  const deletedTaskParentId =
+    selectedEvent?.type === 'task' &&
+    (!selectedEvent?.taskId || selectedEvent.taskId === '') &&
+    selectedEvent?.metadata?.taskSnapshot?.id
+      ? selectedEvent.metadata.taskSnapshot.id
+      : null;
+  const deletedTaskSubtasksResult = useSubtaskRecords(deletedTaskParentId);
+  const deletedTaskSubtasks = deletedTaskParentId ? deletedTaskSubtasksResult : null;
+  const subtasks = useSubtaskRecords(selectedTask?.id && !selectedTask?.parentTaskId ? selectedTask.id : null);
 
   // Watch for newly created task to appear in tasks list
   useEffect(() => {

--- a/apps/web/src/components/FocusView.tsx
+++ b/apps/web/src/components/FocusView.tsx
@@ -1,9 +1,8 @@
 import React, { useEffect, useState, useRef } from 'react';
 import { motion } from 'framer-motion';
 import { Task, TaskUpdate } from '../utils/types';
-import { useBasic, useQuery } from '@basictech/react';
 import { useTheme } from '../contexts/ThemeContext';
-import { readBasicDbSafely, useBasicDbReady } from '../hooks/useBasicDbReady';
+import { useSubtaskRecords, useTaskRecord } from '../hooks/useBasicData';
 import Checkbox from './Checkbox';
 import SubtasksList from './SubtasksList';
 
@@ -23,8 +22,6 @@ const FocusView: React.FC<FocusViewProps> = ({
   onAddSubtask,
   onDeleteSubtask
 }) => {
-  const { db } = useBasic();
-  const isDbReady = useBasicDbReady();
   const { theme } = useTheme();
   const { isDarkMode } = theme;
   
@@ -36,30 +33,9 @@ const FocusView: React.FC<FocusViewProps> = ({
   // Local state for description to prevent cursor jumping
   const [localDescription, setLocalDescription] = useState(task?.description || '');
   
-  // Fetch live task data
-  const liveTask = useQuery(
-    () => readBasicDbSafely(
-      isDbReady,
-      () => task?.id ? db.table<Task>('tasks').get(task.id) : Promise.resolve(null),
-      Promise.resolve(null),
-    ),
-    [isDbReady, task?.id]
-  );
-  
-  // Use live task data if available
+  const liveTask = useTaskRecord(task?.id);
   const currentTask = liveTask || task;
-  
-  // Fetch subtasks
-  const subtasks = (useQuery(
-    () => readBasicDbSafely(
-      isDbReady,
-      () => currentTask?.id && !currentTask?.parentTaskId
-        ? db.table<Task>('tasks').find((t) => t.parentTaskId === currentTask.id)
-        : Promise.resolve(null),
-      Promise.resolve(null),
-    ),
-    [isDbReady, currentTask?.id, currentTask?.parentTaskId]
-  ) || []) as Task[];
+  const subtasks = useSubtaskRecords(currentTask?.id && !currentTask?.parentTaskId ? currentTask.id : null);
 
   // Update elapsed time every second
   useEffect(() => {

--- a/apps/web/src/components/ScheduleCard.tsx
+++ b/apps/web/src/components/ScheduleCard.tsx
@@ -1,10 +1,8 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { motion } from 'framer-motion';
 import Checkbox from './Checkbox';
-import { useBasic, useQuery } from '@basictech/react';
-import { readBasicDbSafely, useBasicDbReady } from '../hooks/useBasicDbReady';
+import { useTaskRecord } from '../hooks/useBasicData';
 import { ScheduleCardData, getEventDuration } from '../utils/schedule';
-import { Task } from '../utils/types';
 
 export interface ScheduleCardProps {
   data: ScheduleCardData;
@@ -68,16 +66,7 @@ const ScheduleCard: React.FC<ScheduleCardProps> = ({
   const duration = getEventDuration(data);
   
   // Fetch linked task if this is a task event
-  const { db } = useBasic();
-  const isDbReady = useBasicDbReady();
-  const linkedTask = useQuery(
-    () => readBasicDbSafely(
-      isDbReady,
-      () => data.taskId && data.taskId !== '' ? db.table<Task>('tasks').get(data.taskId) : Promise.resolve(null),
-      Promise.resolve(null),
-    ),
-    [data.taskId, isDbReady]
-  );
+  const linkedTask = useTaskRecord(data.taskId && data.taskId !== '' ? data.taskId : null);
   
   // Check if this is a deleted task (has snapshot in metadata, taskId is empty string)
   const isDeletedTask = data.type === 'task' && (!data.taskId || data.taskId === '') && data.metadata?.taskSnapshot;

--- a/apps/web/src/components/SettingsPage.tsx
+++ b/apps/web/src/components/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect } from 'react';
-import { useBasic } from "@basictech/react";
+import { basic } from "../basic";
 import { useTheme } from '../contexts/ThemeContext';
 import * as Switch from '@radix-ui/react-switch';
 import { Folder } from '../utils/types';
@@ -54,7 +54,7 @@ function getBackupState({
     };
   }
 
-  if (syncStatus === 'connecting' || syncStatus === 'idle' || !syncStatus) {
+  if (syncStatus === 'connecting' || syncStatus === 'idle' || syncStatus === 'bootstrapping' || !syncStatus) {
     return {
       label: 'Connecting',
       detail: 'Checking backup status…',
@@ -137,12 +137,11 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
   onToggleOtherFolder,
   onToggleTodayFolder,
 }) => {
-  const { sync, signIn, signOut, isSignedIn, isAnonymous, isReady, user, activeUser, status: authStatus } = useBasic();
+  const { sync, signIn, signOut, isSignedIn, isAnonymous, isReady, user, handle, status: authStatus } = basic.useBasic();
   const { theme, setAccentColor, setIsDarkMode, setFontStyle } = useTheme();
   const { accentColor, isDarkMode, fontStyle } = theme;
-  const userProfile = user as { name?: string; username?: string; email?: string } | null;
   const isLocalAccount = isAnonymous || !isSignedIn;
-  const needsReauth = authStatus === "reauth_required" || sync.status === "auth_required" || sync.status === "revoked";
+  const needsReauth = authStatus === "reauth_required";
   const backup = getBackupState({
     isReady,
     isLocalAccount,
@@ -150,9 +149,9 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
     syncStatus: sync.status,
     pendingCount: sync.pendingCount,
   });
-  const accountName = userProfile?.name || activeUser?.name || "Signed in";
-  const accountHandle = userProfile?.username || activeUser?.handle || null;
-  const accountEmail = userProfile?.email || activeUser?.email || null;
+  const accountName = user?.name || "Signed in";
+  const accountHandle = user?.handle || handle || null;
+  const accountEmail = user?.email || null;
   const accountSubtitle = accountHandle
     ? `@${accountHandle.replace(/^@/, "")}`
     : accountEmail;

--- a/apps/web/src/components/SilkTaskDrawer.tsx
+++ b/apps/web/src/components/SilkTaskDrawer.tsx
@@ -8,9 +8,8 @@ import { EventModal } from './EventModal';
 import ListItem from './ListItem';
 import Checkbox from './Checkbox';
 import { ScheduleCardData } from '../utils/schedule';
-import { useBasic, useQuery } from '@basictech/react';
 import { useTheme } from '../contexts/ThemeContext';
-import { readBasicDbSafely, useBasicDbReady } from '../hooks/useBasicDbReady';
+import { useScheduleRecords, useSubtaskRecords, useTaskRecords } from '../hooks/useBasicData';
 import { useModalHistory } from '../hooks/useModalHistory';
 import { Task, Folder } from '../utils/types';
 import './SilkTaskDrawer.css';
@@ -74,14 +73,9 @@ export default function SilkTaskDrawer({
   const [creationMode, setCreationMode] = useState<'task' | 'event'>('task');
   
   // Query all tasks to find created tasks by ID
-  const { db } = useBasic();
-  const isDbReady = useBasicDbReady();
   const { theme } = useTheme();
   const { accentColor, isDarkMode } = theme;
-  const allTasks = (useQuery(
-    () => readBasicDbSafely(isDbReady, () => db.table<Task>("tasks").getAll(), Promise.resolve([] as Task[])),
-    [isDbReady],
-  ) || []) as Task[];
+  const { tasks: allTasks } = useTaskRecords();
   
   // Event creation state
   const [eventTitle, setEventTitle] = useState('');
@@ -91,33 +85,20 @@ export default function SilkTaskDrawer({
   const [eventEndTime, setEventEndTime] = useState('');
   const eventTitleRef = useRef<HTMLInputElement>(null);
   
-  // Fetch scheduled events for the selected task
-  const allScheduleEvents = useQuery(
-    () => readBasicDbSafely(
-      isDbReady,
-      () => db.table<ScheduleCardData>('schedule').getAll(),
-      Promise.resolve([] as ScheduleCardData[]),
-    ),
-    [isDbReady],
-  );
+  const { events: allScheduleEvents } = useScheduleRecords();
   const scheduledEvents = useMemo(() => {
-    if (!task?.id || !allScheduleEvents) return [];
-    return allScheduleEvents.filter((event) => (event as ScheduleCardData).taskId === task.id) as ScheduleCardData[];
+    if (!task?.id) return [];
+    return allScheduleEvents.filter((scheduleEvent) => scheduleEvent.taskId === task.id);
   }, [task?.id, allScheduleEvents]);
 
-  // Query subtasks for deleted task (if viewing a deleted task schedule item)
-  const deletedTaskSubtasks = useQuery(
-    () => readBasicDbSafely(
-      isDbReady,
-      () => event?.type === 'task' &&
-            (!event?.taskId || event?.taskId === '') &&
-            event?.metadata?.taskSnapshot?.id
-        ? db.table<Task>('tasks').find((task) => task.parentTaskId === event.metadata?.taskSnapshot?.id)
-        : Promise.resolve(null),
-      Promise.resolve(null),
-    ),
-    [isDbReady, event?.metadata?.taskSnapshot?.id]
-  ) as Task[] | null;
+  const deletedTaskParentId =
+    event?.type === 'task' &&
+    (!event?.taskId || event.taskId === '') &&
+    event?.metadata?.taskSnapshot?.id
+      ? event.metadata.taskSnapshot.id
+      : null;
+  const deletedTaskSubtasksResult = useSubtaskRecords(deletedTaskParentId);
+  const deletedTaskSubtasks = deletedTaskParentId ? deletedTaskSubtasksResult : null;
 
   // Memoize the placeholder task to ensure stable reference
   const placeholderTask = useMemo(() => ({

--- a/apps/web/src/components/TaskModal.tsx
+++ b/apps/web/src/components/TaskModal.tsx
@@ -3,9 +3,8 @@ import { useState, useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
 import Checkbox from './Checkbox';
 import { ScheduleCardData, getTimeFromDateTime, getEventDuration } from '../utils/schedule';
-import { useBasic, useQuery } from '@basictech/react';
 import { useTheme } from '../contexts/ThemeContext';
-import { readBasicDbSafely, useBasicDbReady } from '../hooks/useBasicDbReady';
+import { useSubtaskRecords } from '../hooks/useBasicData';
 import SubtasksList from './SubtasksList';
 import { useAutoResizeTextarea } from '../hooks/useAutoResizeTextarea';
 import { showPickerOrClick } from '../utils/showPicker';
@@ -47,20 +46,7 @@ export const TaskModal = ({
   const nameInputRef = useRef<HTMLTextAreaElement | null>(null);
   const descTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   
-  // Query subtasks for this task
-  const { db } = useBasic();
-  const isDbReady = useBasicDbReady();
-  const subtasksData = useQuery(
-    () => readBasicDbSafely(
-      isDbReady,
-      () => task?.id && !task?.parentTaskId
-        ? db.table<Task>('tasks').find((t) => t.parentTaskId === task.id)
-        : Promise.resolve(null),
-      Promise.resolve(null),
-    ),
-    [isDbReady, task?.id, task?.parentTaskId]
-  );
-  const subtasks: Task[] = (subtasksData || []) as Task[];
+  const subtasks = useSubtaskRecords(task?.id && !task?.parentTaskId ? task.id : null);
 
   // Check if task has any scheduled events for today
   const hasScheduledEventToday = (() => {

--- a/apps/web/src/components/TimelineView.tsx
+++ b/apps/web/src/components/TimelineView.tsx
@@ -2,10 +2,9 @@ import React, { useState, useMemo, useRef, useEffect, useCallback } from 'react'
 import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ScheduleCardData, ScheduleCardInput, getEventDuration } from '../utils/schedule';
-import { useBasic, useQuery } from '@basictech/react';
-import { readBasicDbSafely, useBasicDbReady } from '../hooks/useBasicDbReady';
+import { useTaskRecord } from '../hooks/useBasicData';
 import Checkbox from './Checkbox';
-import { Folder, Task } from '../utils/types';
+import { Folder } from '../utils/types';
 
 interface TimelineSegment {
   startMinutes: number;
@@ -1330,18 +1329,7 @@ const TimelineEventCard: React.FC<TimelineEventCardProps> = ({
   hasAdjacentBelow = false,
   adjacentCorners = { topLeft: false, topRight: false, bottomLeft: false, bottomRight: false }
 }) => {
-  const { db } = useBasic();
-  const isDbReady = useBasicDbReady();
-  
-  // Fetch linked task if this is a task event (only if taskId is not empty)
-  const linkedTask = useQuery(
-    () => readBasicDbSafely(
-      isDbReady,
-      () => event.taskId && event.taskId !== '' ? db.table<Task>('tasks').get(event.taskId) : Promise.resolve(null),
-      Promise.resolve(null),
-    ),
-    [event.taskId, isDbReady]
-  );
+  const linkedTask = useTaskRecord(event.taskId && event.taskId !== '' ? event.taskId : null);
   
   // Check if this is a deleted task (has snapshot in metadata, taskId is empty string)
   const taskSnapshot = event.metadata?.taskSnapshot;

--- a/apps/web/src/components/UserAvatarButton.tsx
+++ b/apps/web/src/components/UserAvatarButton.tsx
@@ -1,12 +1,11 @@
 import { useState } from "react";
-import { useBasic } from "@basictech/react";
+import { basic } from "../basic";
 import * as Popover from '@radix-ui/react-popover';
 import packageJson from '../../package.json';
 
 function UserAvatarButton() {
-  const { signIn, signOut, isSignedIn, user, isReady, sync } = useBasic();
+  const { signIn, signOut, isSignedIn, user, isReady, sync, status } = basic.useBasic();
   const [hasNotifications] = useState(true);
-  const userProfile = user as { name?: string; username?: string } | null;
 
   const handleLogin = () => {
     void signIn();
@@ -18,14 +17,16 @@ function UserAvatarButton() {
 
   // Determine notification dot color based on sync status
   const getNotificationColor = () => {
+    if (status === "reauth_required" || sync.status === "error") {
+      return "bg-red-500";
+    }
+
     switch (sync.status) {
       case "online":
         return "bg-green-500";
       case "offline":
+      case "ended":
         return "bg-gray-400";
-      case "revoked":
-      case "auth_required":
-        return "bg-red-500";
       default:
         return "bg-yellow-500";
     }
@@ -43,7 +44,7 @@ function UserAvatarButton() {
             className="rounded-full flex items-center justify-center bg-[#1F1B2F] text-white w-8 h-8 overflow-hidden"
           >
             {isSignedIn ? (
-              <span className="flex items-center justify-center w-full h-full">{userProfile?.name?.slice(0, 1)}</span>
+              <span className="flex items-center justify-center w-full h-full">{user?.name?.slice(0, 1)}</span>
             ) : (
               <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor" className="w-5 h-5">
                 <path fillRule="evenodd" d="M18.685 19.097A9.723 9.723 0 0021.75 12c0-5.385-4.365-9.75-9.75-9.75S2.25 6.615 2.25 12a9.723 9.723 0 003.065 7.097A9.716 9.716 0 0012 21.75a9.716 9.716 0 006.685-2.653zm-12.54-1.285A7.486 7.486 0 0112 15a7.486 7.486 0 015.855 2.812A8.224 8.224 0 0112 20.25a8.224 8.224 0 01-5.855-2.438zM15.75 9a3.75 3.75 0 11-7.5 0 3.75 3.75 0 017.5 0z" clipRule="evenodd" />
@@ -65,10 +66,10 @@ function UserAvatarButton() {
             {isSignedIn ? (
               <div className="p-4 text-left bg-[#1F1B2F]">
                 <p className="text-slate-100 font-medium">
-                  hi, {userProfile?.name}
+                  hi, {user?.name}
                 </p>
-                {userProfile?.username && (
-                  <p className="text-gray-400 text-sm mt-0.5">@{userProfile.username}</p>
+                {user?.handle && (
+                  <p className="text-gray-400 text-sm mt-0.5">@{user.handle}</p>
                 )}
 
                 <div className="border-t border-gray-600 my-4"></div>

--- a/apps/web/src/components/UserAvatarButton.tsx
+++ b/apps/web/src/components/UserAvatarButton.tsx
@@ -8,7 +8,9 @@ function UserAvatarButton() {
   const [hasNotifications] = useState(true);
 
   const handleLogin = () => {
-    void signIn();
+    void signIn().catch((error) => {
+      console.error("Basic sign-in failed", error);
+    });
   };
 
   const handleLogout = () => {

--- a/apps/web/src/hooks/useAppActions.ts
+++ b/apps/web/src/hooks/useAppActions.ts
@@ -1,9 +1,10 @@
-import { useBasic } from "@basictech/react";
 import { type Dispatch, type SetStateAction, useCallback, useEffect, useRef, useState } from "react";
-import { useBasicDbReady } from "./useBasicDbReady";
+import { basic } from "../basic";
+import { unwrapScheduleEvent, unwrapScheduleEvents, unwrapTask } from "../utils/basicRecords";
 import { Folder, FolderUpdate, Task, TaskUpdate } from "../utils/types";
 import { fetchWeatherData } from "../utils/weather";
 import { ScheduleCardData, ScheduleCardInput, ScheduleCardUpdate } from "../utils/schedule";
+import { useBasicDbReady } from "./useBasicDbReady";
 
 interface ThemeLocation {
   latitude: number;
@@ -37,11 +38,10 @@ export function useAppActions({
   setSelectedTask,
   themeLocation,
 }: UseAppActionsOptions) {
-  const { db } = useBasic();
   const isDbReady = useBasicDbReady();
-  const scheduleTable = db.table<ScheduleCardData>("schedule");
-  const tasksTable = db.table<Task>("tasks");
-  const filtersTable = db.table<Folder>("filters");
+  const scheduleTable = basic.useCollection("schedule");
+  const tasksTable = basic.useCollection("tasks");
+  const filtersTable = basic.useCollection("filters");
   const [focusedTask, setFocusedTask] = useState<Task | null>(null);
   const [focusSessionEventId, setFocusSessionEventId] = useState<string | null>(null);
   const fetchingWeatherDatesRef = useRef<Set<string>>(new Set());
@@ -116,7 +116,7 @@ export function useAppActions({
         return;
       }
 
-      const eventRecord = await scheduleTable.create({
+      const { record } = await scheduleTable.create({
         title: `${task.name} (focus session)`,
         start: {
           dateTime: now.toISOString(),
@@ -132,7 +132,7 @@ export function useAppActions({
         description: "Focus session",
       });
 
-      setFocusSessionEventId(eventRecord.id);
+      setFocusSessionEventId(unwrapScheduleEvent(record)?.id ?? null);
     },
     [isDbReady, scheduleEvents, scheduleTable, setDrawerOpen, setSelectedEvent, setSelectedTask],
   );
@@ -331,7 +331,12 @@ export function useAppActions({
         throw new Error("Basic database is not ready yet.");
       }
 
-      return scheduleTable.create(eventData);
+      const { record } = await scheduleTable.create(eventData);
+      const created = unwrapScheduleEvent(record);
+      if (!created) {
+        throw new Error("Basic create did not return a live schedule event.");
+      }
+      return created;
     },
     [isDbReady, scheduleTable],
   );
@@ -348,10 +353,11 @@ export function useAppActions({
       const todayEnd = new Date(now);
       todayEnd.setHours(23, 59, 59, 999);
 
-      const existingCompletionEvents = await scheduleTable.find((scheduleEvent) =>
+      const existingCompletionEvents = unwrapScheduleEvents(
+        (await scheduleTable.list({ where: { taskId: task.id } })).data,
+      ).filter((scheduleEvent) =>
         Boolean(
           scheduleEvent.type === "task:completed" &&
-            scheduleEvent.taskId === task.id &&
             scheduleEvent.start.dateTime &&
             new Date(scheduleEvent.start.dateTime) >= todayStart &&
             new Date(scheduleEvent.start.dateTime) <= todayEnd,
@@ -391,7 +397,7 @@ export function useAppActions({
       }
 
       if (changes.completed === true) {
-        const task = await tasksTable.get(taskId);
+        const task = unwrapTask(await tasksTable.get(taskId));
         if (task && !task.completed) {
           await createTaskCompletionEvent(task);
         }
@@ -415,10 +421,12 @@ export function useAppActions({
         return;
       }
 
-      const scheduleItems = await scheduleTable.find((item) => item.taskId === taskId);
+      const scheduleItems = unwrapScheduleEvents(
+        (await scheduleTable.list({ where: { taskId } })).data,
+      );
 
       if (scheduleItems.length > 0) {
-        const task = await tasksTable.get(taskId);
+        const task = unwrapTask(await tasksTable.get(taskId));
 
         if (task) {
           const taskSnapshot = {
@@ -463,14 +471,14 @@ export function useAppActions({
         }
       }
 
-      const result = await tasksTable.create({
+      const { record } = await tasksTable.create({
         name: taskName,
         description: "",
         completed: false,
         labels,
       });
 
-      const taskId = result.id;
+      const taskId = unwrapTask(record)?.id;
 
       if (activeFolder === "today" && taskId) {
         await handleAddToSchedule({
@@ -493,14 +501,14 @@ export function useAppActions({
         return null;
       }
 
-      const result = await tasksTable.create({
+      const { record } = await tasksTable.create({
         name: subtaskName,
         description: "",
         completed: false,
         parentTaskId,
       });
 
-      return result.id ?? null;
+      return unwrapTask(record)?.id ?? null;
     },
     [isDbReady, tasksTable],
   );

--- a/apps/web/src/hooks/useBasicData.ts
+++ b/apps/web/src/hooks/useBasicData.ts
@@ -1,0 +1,48 @@
+import { useMemo } from "react";
+import { basic } from "../basic";
+import { unwrapFolders, unwrapScheduleEvents, unwrapTasks } from "../utils/basicRecords";
+import type { Task } from "../utils/types";
+import type { ScheduleCardData } from "../utils/schedule";
+
+export function useTaskRecords() {
+  const { data, isLoading, error } = basic.useQuery("tasks");
+  const tasks = useMemo(() => unwrapTasks(data), [data]);
+  return { tasks, isLoading, error };
+}
+
+export function useScheduleRecords(taskId?: string | null) {
+  const { data, isLoading, error } = basic.useQuery(
+    "schedule",
+    taskId ? { where: { taskId } } : undefined,
+  );
+  const events = useMemo(() => unwrapScheduleEvents(data), [data]);
+  return { events, isLoading, error };
+}
+
+export function useFolderRecords() {
+  const { data, isLoading, error } = basic.useQuery("filters");
+  const folders = useMemo(() => unwrapFolders(data), [data]);
+  return { folders, isLoading, error };
+}
+
+export function useTaskRecord(id: string | null | undefined): Task | null {
+  const { tasks } = useTaskRecords();
+  return useMemo(() => (id ? tasks.find((task) => task.id === id) ?? null : null), [id, tasks]);
+}
+
+export function useScheduleRecord(id: string | null | undefined): ScheduleCardData | null {
+  const { events } = useScheduleRecords();
+  return useMemo(() => (id ? events.find((event) => event.id === id) ?? null : null), [events, id]);
+}
+
+export function useSubtaskRecords(parentTaskId: string | null | undefined): Task[] {
+  const { data } = basic.useQuery("tasks", {
+    where: { parentTaskId: parentTaskId ?? "" },
+  });
+
+  return useMemo(
+    () => (parentTaskId ? unwrapTasks(data) : []),
+    [data, parentTaskId],
+  );
+}
+

--- a/apps/web/src/hooks/useBasicDbReady.test.ts
+++ b/apps/web/src/hooks/useBasicDbReady.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+import { isBasicDbWritable } from "./useBasicDbReady";
+
+describe("isBasicDbWritable", () => {
+  it("is false until the client is ready", () => {
+    expect(isBasicDbWritable(false, "local")).toBe(false);
+    expect(isBasicDbWritable(false, "online")).toBe(false);
+  });
+
+  it("allows writes for local and connected sync states", () => {
+    expect(isBasicDbWritable(true, "local")).toBe(true);
+    expect(isBasicDbWritable(true, "online")).toBe(true);
+    expect(isBasicDbWritable(true, "offline")).toBe(true);
+    expect(isBasicDbWritable(true, "idle")).toBe(true);
+  });
+
+  it("allows writes while sync is still connecting or has a recoverable error", () => {
+    expect(isBasicDbWritable(true, "bootstrapping")).toBe(true);
+    expect(isBasicDbWritable(true, "connecting")).toBe(true);
+    expect(isBasicDbWritable(true, "error")).toBe(true);
+    expect(isBasicDbWritable(true, "stale")).toBe(true);
+  });
+
+  it("blocks writes only after the client has stopped", () => {
+    expect(isBasicDbWritable(true, "stopped")).toBe(false);
+  });
+});

--- a/apps/web/src/hooks/useBasicDbReady.ts
+++ b/apps/web/src/hooks/useBasicDbReady.ts
@@ -1,12 +1,14 @@
 import { basic } from "../basic";
 
+export function isBasicDbWritable(isReady: boolean, syncStatus: string | undefined) {
+  // Local replica writes should work as soon as the client is ready. After
+  // OAuth, sync can sit in bootstrapping/connecting/error while the replica is
+  // already usable; blocking those states silently dropped creates.
+  return isReady && syncStatus !== "stopped";
+}
+
 export function useBasicDbReady() {
   const { isReady, sync } = basic.useBasic();
 
-  return isReady && (
-    sync.status === "local" ||
-    sync.status === "online" ||
-    sync.status === "offline" ||
-    sync.status === "idle"
-  );
+  return isBasicDbWritable(isReady, sync.status);
 }

--- a/apps/web/src/hooks/useBasicDbReady.ts
+++ b/apps/web/src/hooks/useBasicDbReady.ts
@@ -1,43 +1,12 @@
-import { useBasic } from "@basictech/react";
-
-const BASIC_SUBSCRIPTION_NOT_OPEN_MESSAGE = "subscription 'own' is not open";
+import { basic } from "../basic";
 
 export function useBasicDbReady() {
-  const { isReady, sync } = useBasic();
+  const { isReady, sync } = basic.useBasic();
 
-  // Basic 0.9.0-beta.1 exposes a local-first mode where the app DB can be
-  // usable before sign-in. `local` is a real ready state, not just a loading phase.
-  return isReady && (sync.status === "local" || sync.status === "online" || sync.status === "offline");
-}
-
-export function isBasicDbNotReadyError(error: unknown) {
-  return error instanceof Error && error.message.includes(BASIC_SUBSCRIPTION_NOT_OPEN_MESSAGE);
-}
-
-export function readBasicDbSafely<T>(isDbReady: boolean, read: () => T, fallback: T): T {
-  if (!isDbReady) {
-    return fallback;
-  }
-
-  try {
-    const result = read();
-
-    if (result instanceof Promise) {
-      return result.catch((error) => {
-        if (isBasicDbNotReadyError(error)) {
-          return fallback;
-        }
-
-        throw error;
-      }) as T;
-    }
-
-    return result;
-  } catch (error) {
-    if (isBasicDbNotReadyError(error)) {
-      return fallback;
-    }
-
-    throw error;
-  }
+  return isReady && (
+    sync.status === "local" ||
+    sync.status === "online" ||
+    sync.status === "offline" ||
+    sync.status === "idle"
+  );
 }

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -3,9 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App";
 import "./index.css";
 
-import { BasicProvider } from "@basictech/react";
-
-import { schema } from "../basic.config";
+import { basic } from "./basic";
 import './registerSW';
 
 // Fix for mobile Chrome address bar collapsing issue
@@ -30,9 +28,9 @@ if (typeof CSS === 'undefined' || !CSS.supports('height', '100dvh')) {
 
 ReactDOM.createRoot(document.getElementById("root") as HTMLElement).render(
   <React.StrictMode>
-    <BasicProvider schema={schema} debug={import.meta.env.DEV}>
+    <basic.Provider renderWhileLoading>
       <App />
-    </BasicProvider>
+    </basic.Provider>
   </React.StrictMode>
 );
 

--- a/apps/web/src/utils/basicRecords.test.ts
+++ b/apps/web/src/utils/basicRecords.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+import { unwrapRecord, unwrapRecords, unwrapTask, unwrapTasks } from "./basicRecords";
+
+describe("basic record helpers", () => {
+  it("unwraps a live record into a flat app object", () => {
+    const task = unwrapRecord({
+      id: "task-1",
+      value: { name: "Write docs", completed: false },
+      meta: { state: "live" as const },
+    });
+
+    expect(task).toEqual({
+      id: "task-1",
+      name: "Write docs",
+      completed: false,
+    });
+  });
+
+  it("returns null for missing, purged, or empty values", () => {
+    expect(unwrapRecord(null)).toBeNull();
+    expect(unwrapRecord(undefined)).toBeNull();
+    expect(unwrapRecord({
+      id: "gone",
+      value: null,
+      meta: { state: "purged" as const },
+    })).toBeNull();
+  });
+
+  it("drops records without values when unwrapping a page", () => {
+    const tasks = unwrapRecords([
+      {
+        id: "live",
+        value: { name: "Keep" },
+        meta: { state: "live" as const },
+      },
+      {
+        id: "purged",
+        value: null,
+        meta: { state: "purged" as const },
+      },
+    ]);
+
+    expect(tasks).toEqual([{ id: "live", name: "Keep" }]);
+  });
+
+  it("preserves task fields used by the app", () => {
+    const tasks = unwrapTasks([
+      {
+        id: "parent",
+        value: {
+          name: "Ship",
+          description: "",
+          completed: true,
+          labels: "folder:today",
+          parentTaskId: "",
+        },
+      },
+    ]);
+
+    expect(tasks[0]).toMatchObject({
+      id: "parent",
+      name: "Ship",
+      completed: true,
+      labels: "folder:today",
+    });
+    expect(unwrapTask({
+      id: "parent",
+      value: {
+        name: "Ship",
+        description: "",
+        completed: true,
+        labels: "folder:today",
+        parentTaskId: "",
+      },
+    })).toMatchObject({
+      id: "parent",
+      name: "Ship",
+      completed: true,
+      labels: "folder:today",
+    });
+  });
+});

--- a/apps/web/src/utils/basicRecords.ts
+++ b/apps/web/src/utils/basicRecords.ts
@@ -1,0 +1,55 @@
+import type { BasicRecord } from "@basictech/core";
+import type { ScheduleCardData } from "./schedule";
+import type { Folder, Task } from "./types";
+
+export function unwrapRecord<T extends object>(
+  record: BasicRecord<T> | null | undefined,
+): (T & { id: string }) | null {
+  if (!record?.value) {
+    return null;
+  }
+
+  return { id: record.id, ...record.value };
+}
+
+export function unwrapRecords<T extends object>(
+  records: Array<BasicRecord<T>>,
+): Array<T & { id: string }> {
+  return records.flatMap((record) => {
+    const item = unwrapRecord(record);
+    return item ? [item] : [];
+  });
+}
+
+type RecordLike<T extends object> = {
+  id: string;
+  value: T | null;
+};
+
+export function unwrapTask(record: RecordLike<object> | null | undefined): Task | null {
+  return unwrapRecord(record as BasicRecord<object> | null | undefined) as Task | null;
+}
+
+export function unwrapTasks(records: Array<RecordLike<object>>): Task[] {
+  return unwrapRecords(records as Array<BasicRecord<object>>) as Task[];
+}
+
+export function unwrapFolder(record: RecordLike<object> | null | undefined): Folder | null {
+  return unwrapRecord(record as BasicRecord<object> | null | undefined) as Folder | null;
+}
+
+export function unwrapFolders(records: Array<RecordLike<object>>): Folder[] {
+  return unwrapRecords(records as Array<BasicRecord<object>>) as Folder[];
+}
+
+export function unwrapScheduleEvent(
+  record: RecordLike<object> | null | undefined,
+): ScheduleCardData | null {
+  return unwrapRecord(record as BasicRecord<object> | null | undefined) as ScheduleCardData | null;
+}
+
+export function unwrapScheduleEvents(
+  records: Array<RecordLike<object>>,
+): ScheduleCardData[] {
+  return unwrapRecords(records as Array<BasicRecord<object>>) as ScheduleCardData[];
+}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,1 +1,9 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_BASIC_CLIENT_ID?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
+    "moduleResolution": "bundler",
     "types": [
       "vite-plugin-pwa/client"
     ]

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,9 +1,24 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react-swc";
 import { VitePWA } from 'vite-plugin-pwa';
+import { basicPdsProxyTarget, stripBasicPdsProxyPrefix } from "./src/basicDevProxy";
 
 // https://vitejs.dev/config/
 export default defineConfig({
+  server: {
+    proxy: {
+      "/__basic-pds": {
+        target: "https://pds.basic.id",
+        changeOrigin: true,
+        secure: true,
+        ws: true,
+        router(req) {
+          return basicPdsProxyTarget(req.url ?? "");
+        },
+        rewrite: stripBasicPdsProxyPrefix,
+      },
+    },
+  },
   plugins: [
     react(),
     VitePWA({

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,8 @@
       "name": "@tsk/web",
       "version": "7.0.0",
       "dependencies": {
-        "@basictech/react": "0.9.0-beta.1",
+        "@basictech/react": "^0.11.0-beta.1",
+        "@basictech/schema": "^0.11.0-beta.1",
         "@radix-ui/react-popover": "^1.1.19",
         "@radix-ui/react-switch": "^1.3.3",
         "@silk-hq/components": "^0.8.15",
@@ -1886,30 +1887,45 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@basictech/react": {
-      "version": "0.9.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@basictech/react/-/react-0.9.0-beta.1.tgz",
-      "integrity": "sha512-c4ww1h1fuZu1lJvjHv596AOBpieSKf5Eu/Og258NQi2i44YjB5mf7tlgTsN6bkH2lTE6nxrpa8VnPcjJ9bmACg==",
-      "license": "ISC",
+    "node_modules/@basictech/core": {
+      "version": "0.11.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@basictech/core/-/core-0.11.0-beta.1.tgz",
+      "integrity": "sha512-TBAZuYFAern975/7AHoZ01VYushNfl1BF3BBav7yGWqr6HxSNxAqZUn5zVYvPdxT7VBNbRwwdIJ859QWNFrp8Q==",
+      "license": "MIT",
       "dependencies": {
-        "@basictech/schema": "^0.7.0",
-        "dexie": "^4.2.1",
-        "dexie-react-hooks": "^4.2.0",
-        "jwt-decode": "^4.0.0",
-        "semver": "^7.7.2"
+        "@basictech/schema": "0.11.0-beta.1"
+      },
+      "engines": {
+        "node": ">=24.0.0"
+      }
+    },
+    "node_modules/@basictech/react": {
+      "version": "0.11.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@basictech/react/-/react-0.11.0-beta.1.tgz",
+      "integrity": "sha512-Qlx9hhanYbHEDDhs2ka7iCpqk+vcLKVPLXaZJAuF1OxTL/LQsgL98GMAodU7ER07JdXfQR84c7SyAlj/ZDzGtA==",
+      "license": "MIT",
+      "dependencies": {
+        "@basictech/core": "0.11.0-beta.1",
+        "dexie": "^4.2.1"
+      },
+      "engines": {
+        "node": ">=24.0.0"
       },
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+        "react": ">=18"
       }
     },
     "node_modules/@basictech/schema": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@basictech/schema/-/schema-0.7.0.tgz",
-      "integrity": "sha512-++pPT99/dHzzkpHXSUM+2RyCJO0AXqi56sRlBeDZRSBOnWSW+yUhaJjzqMOOSytsRI6MTm3rSLIxs122+2ojLw==",
-      "license": "ISC",
+      "version": "0.11.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@basictech/schema/-/schema-0.11.0-beta.1.tgz",
+      "integrity": "sha512-Chkq8GKqR1IS9CrQbwSRCgbPtaJSI+ZROgkVSnt07tHZP6VLFyH0u5MVvqtQiKxrwKYMHUDXgp+Y/DoLDR8HZQ==",
+      "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",
         "ajv-errors": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@basictech/schema/node_modules/ajv": {
@@ -4435,6 +4451,7 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -5621,7 +5638,8 @@
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
-      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true
     },
     "node_modules/data-urls": {
       "version": "7.0.0",
@@ -5811,19 +5829,10 @@
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ=="
     },
     "node_modules/dexie": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.2.1.tgz",
-      "integrity": "sha512-Ckej0NS6jxQ4Po3OrSQBFddayRhTCic2DoCAG5zacOfOVB9P2Q5Xc5uL/nVa7ZVs+HdMnvUPzLFCB/JwpB6Csg=="
-    },
-    "node_modules/dexie-react-hooks": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/dexie-react-hooks/-/dexie-react-hooks-4.2.0.tgz",
-      "integrity": "sha512-u7KqTX9JpBQK8+tEyA9X0yMGXlSCsbm5AU64N6gjvGk/IutYDpLBInMYEAEC83s3qhIvryFS+W+sqLZUBEvePQ==",
-      "peerDependencies": {
-        "@types/react": ">=16",
-        "dexie": ">=4.2.0-alpha.1 <5.0.0",
-        "react": ">=16"
-      }
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/dexie/-/dexie-4.4.5.tgz",
+      "integrity": "sha512-wWCHdihT3dmlUSuNhn5mMZDWSpG0suxjAni7YjjiZdzabZcKmy3uNZGZ7AeYYXBoLbpSXX35fikPLkPC44Osiw==",
+      "license": "Apache-2.0"
     },
     "node_modules/didyoumean": {
       "version": "1.2.2",
@@ -7834,14 +7843,6 @@
         "node": ">=4.0"
       }
     },
-    "node_modules/jwt-decode": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
-      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -9111,6 +9112,7 @@
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Upgrade `@basictech/react` from `0.9.0-beta.1` to `0.11.0-beta.1`. This is a breaking SDK rewrite, so the web app now uses the documented 0.11 factory, schema, and record APIs instead of the old provider/table surface.

## What changed
- Install `@basictech/react@0.11.0-beta.1` and `@basictech/schema@0.11.0-beta.1`
- Define the project schema with `defineSchema` and create a module-scoped `createBasic` client
- Wrap the app in `basic.Provider`
- Read records as `{ id, value, meta }` envelopes and unwrap them for existing app types
- Replace `useQuery(() => db.table().getAll())` / `.find()` / `.get()` with `basic.useQuery` and typed collection mutations (`create`, `patch`, `list`, `delete`)
- Update auth/sync UI for the 0.11 status model (`reauth_required`, `handle`, no `activeUser`)

## Notes
- Default OAuth client ID is `did:web:tsk.lol`, overridable with `VITE_BASIC_CLIENT_ID`
- Existing user data still uses schema version 6; field shapes are unchanged
- Backwards compatibility with the 0.9 SDK APIs is intentionally not preserved

## Verification
- `npm run lint`
- `npm run test`
- `npm run build`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fb9627c-db98-4e4d-84e5-fc1e233d7152?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fb9627c-db98-4e4d-84e5-fc1e233d7152&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

