### PR TITLE
Add simple sharing for individual tasks

### DIFF
--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -13,6 +13,7 @@ import ListItem from "./components/ListItem";
 import MobileNavBar from "./components/MobileNavBar";
 import ScheduleSidebar from "./components/ScheduleSidebar";
 import SettingsPage from "./components/SettingsPage";
+import SharedTasksView from "./components/SharedTasksView";
 import SilkTaskDrawer from "./components/SilkTaskDrawer";
 import UserAvatarButton from "./components/UserAvatarButton";
 import { ThemeProvider, useTheme } from "./contexts/ThemeContext";
@@ -369,6 +370,7 @@ function Home() {
                       showAllFolder={showAllFolder}
                       showOtherFolder={showOtherFolder}
                       showTodayFolder={showTodayFolder}
+                      showSharedFolder
                     />
 
                     <div
@@ -383,13 +385,21 @@ function Home() {
                     >
                       <div className="mt-10 flex justify-center">
                         <div className="w-full max-w-2xl relative">
-                          {showDelayedLoadingState && filteredTasks.length === 0 && (
+                          {activeFolder === "shared" ? (
+                            <SharedTasksView
+                              viewMode={viewMode}
+                              isMobile={isMobile}
+                              isDarkMode={theme.isDarkMode}
+                            />
+                          ) : null}
+
+                          {activeFolder !== "shared" && showDelayedLoadingState && filteredTasks.length === 0 && (
                             <div className="task-loading-state" aria-live="polite" aria-busy="true">
                               <div className="task-loading-spinner" />
                             </div>
                           )}
 
-                          {!isCollectionsLoading && filteredTasks.length === 0 && (
+                          {activeFolder !== "shared" && !isCollectionsLoading && filteredTasks.length === 0 && (
                             <div>
                               {activeFolder === "today" ? (
                                 <>
@@ -417,7 +427,7 @@ function Home() {
                           )}
 
                           <div className={`flex flex-col ${viewMode === "compact" ? "space-y-0" : viewMode === "cozy" ? "space-y-1" : "space-y-2"}`}>
-                            {filteredTasks.map((task) => (
+                            {activeFolder !== "shared" && filteredTasks.map((task) => (
                               <div key={task.id} className="w-full">
                                 <ListItem
                                   task={task}
@@ -434,7 +444,7 @@ function Home() {
                             ))}
                           </div>
 
-                          {((activeFolder === "today" && suggestedTasks.length > 0) || completedTasks.length > 0) && (
+                          {activeFolder !== "shared" && ((activeFolder === "today" && suggestedTasks.length > 0) || completedTasks.length > 0) && (
                             <div className={`mt-8 ${filteredTasks.length > 0 ? "pt-8" : ""}`}>
                               <div className="flex items-center gap-4 mb-4">
                                 {activeFolder === "today" && suggestedTasks.length > 0 && (

--- a/apps/web/src/components/DynamicIsland.tsx
+++ b/apps/web/src/components/DynamicIsland.tsx
@@ -6,6 +6,7 @@ import Checkbox from './Checkbox';
 import { useTheme } from '../contexts/ThemeContext';
 import { useScheduleRecord, useScheduleRecords, useSubtaskRecords, useTaskRecord } from '../hooks/useBasicData';
 import SubtasksList from './SubtasksList';
+import TaskSharePanel from './TaskSharePanel';
 import { useAutoResizeTextarea } from '../hooks/useAutoResizeTextarea';
 
 interface DynamicIslandProps {
@@ -1403,6 +1404,14 @@ const DynamicIsland: React.FC<DynamicIslandProps> = ({
                   placeholder="Add a description..."
                   style={{ height: 'auto' }}
                 />
+
+                {currentTask?.id ? (
+                  <TaskSharePanel
+                    taskId={currentTask.id}
+                    taskName={currentTask.name || title}
+                    compact
+                  />
+                ) : null}
 
               {/* Activity Section - show scheduled events if any exist */}
               {scheduledEvents && scheduledEvents.length > 0 && (() => {

--- a/apps/web/src/components/FoldersBar.tsx
+++ b/apps/web/src/components/FoldersBar.tsx
@@ -8,6 +8,7 @@ interface FoldersBarProps {
   showAllFolder?: boolean;
   showOtherFolder?: boolean;
   showTodayFolder?: boolean;
+  showSharedFolder?: boolean;
   isDarkMode?: boolean;
 }
 
@@ -18,6 +19,7 @@ const FoldersBar: React.FC<FoldersBarProps> = ({
   showAllFolder = false,
   showOtherFolder = true,
   showTodayFolder = true,
+  showSharedFolder = true,
   isDarkMode = true,
 }) => {
   const scrollContainerRef = useRef<HTMLDivElement>(null);
@@ -84,6 +86,8 @@ const FoldersBar: React.FC<FoldersBarProps> = ({
         ))}
 
         {showTodayFolder ? renderChip('today', 'Today') : null}
+
+        {showSharedFolder ? renderChip('shared', 'Shared') : null}
 
         {showAllFolder ? renderChip('all', 'All') : null}
         </div>

--- a/apps/web/src/components/SettingsPage.tsx
+++ b/apps/web/src/components/SettingsPage.tsx
@@ -101,7 +101,7 @@ function SharingSettings() {
       </p>
       <button
         type="button"
-        onClick={() => { window.location.assign(shares.manageUrl()); }}
+        onClick={() => { window.location.assign("https://basic.id/shares"); }}
         className={`w-full px-4 py-2.5 rounded-lg text-sm font-medium transition-colors ${
           isDarkMode
             ? 'bg-white/15 hover:bg-white/25'

--- a/apps/web/src/components/SettingsPage.tsx
+++ b/apps/web/src/components/SettingsPage.tsx
@@ -85,6 +85,35 @@ function getBackupState({
   };
 }
 
+function SharingSettings() {
+  const shares = basic.useOutgoingShares();
+  const mounts = basic.useMounts();
+  const { theme } = useTheme();
+  const { isDarkMode } = theme;
+  const openShares = shares.outgoingShares.filter((share) => share.state === "pending" || share.state === "active");
+
+  return (
+    <section className={`rounded-xl p-4 ${isDarkMode ? 'bg-white/5' : 'bg-black/5'}`}>
+      <h2 className="text-lg font-semibold mb-2">Sharing</h2>
+      <p className={`text-sm mb-4 ${isDarkMode ? 'text-gray-400' : 'text-gray-600'}`}>
+        Share individual tasks from a task’s details. {openShares.length === 1 ? "1 task is" : `${openShares.length} tasks are`} shared outbound
+        {mounts.mounts.length > 0 ? `, and ${mounts.mounts.length} ${mounts.mounts.length === 1 ? "share is" : "shares are"} incoming.` : "."}
+      </p>
+      <button
+        type="button"
+        onClick={() => { window.location.assign(shares.manageUrl()); }}
+        className={`w-full px-4 py-2.5 rounded-lg text-sm font-medium transition-colors ${
+          isDarkMode
+            ? 'bg-white/15 hover:bg-white/25'
+            : 'bg-black/10 hover:bg-black/15'
+        }`}
+      >
+        Manage shares in Basic ID
+      </button>
+    </section>
+  );
+}
+
 const backupToneClass: Record<BackupTone, string> = {
   good: 'bg-green-500',
   warn: 'bg-yellow-500',
@@ -412,6 +441,10 @@ const SettingsPage: React.FC<SettingsPageProps> = ({
                   ) : null}
                 </div>
               </section>
+
+              {isReady && !isLocalAccount ? (
+                <SharingSettings />
+              ) : null}
 
               {/* About */}
               <section className={`rounded-xl p-4 ${isDarkMode ? 'bg-white/5' : 'bg-black/5'}`}>

--- a/apps/web/src/components/SharedTasksView.tsx
+++ b/apps/web/src/components/SharedTasksView.tsx
@@ -1,0 +1,163 @@
+import { useMemo } from "react";
+import { basic } from "../basic";
+import { useOpenedMounts } from "../hooks/useOpenedMounts";
+import { unwrapTasks } from "../utils/basicRecords";
+import { shortDid } from "../utils/shares";
+import type { TaskUpdate } from "../utils/types";
+import ListItem from "./ListItem";
+
+interface SharedTasksViewProps {
+  viewMode: "compact" | "cozy" | "chonky";
+  isMobile: boolean;
+  isDarkMode: boolean;
+}
+
+export default function SharedTasksView({ viewMode, isMobile, isDarkMode }: SharedTasksViewProps) {
+  const { isReady, isSignedIn, isLoading, error, mounts, manageUrl } = useOpenedMounts();
+  const { signIn } = basic.useAuth();
+
+  if (!isReady || isLoading) {
+    return (
+      <div className="task-loading-state" aria-live="polite" aria-busy="true">
+        <div className="task-loading-spinner" />
+      </div>
+    );
+  }
+
+  if (!isSignedIn) {
+    return (
+      <div className="text-center">
+        <p className={`text-lg font-bold ${isDarkMode ? "text-slate-100" : "text-gray-900"}`}>
+          Sign in to see shared tasks
+        </p>
+        <p className={`no-task-blurb text-sm font-serif mt-2 ${isDarkMode ? "text-slate-100" : "text-gray-700"}`}>
+          Friends can share individual tasks with you through Basic.
+        </p>
+        <button
+          type="button"
+          onClick={() => { void signIn(); }}
+          className="mt-4 px-4 py-2 rounded-lg bg-white/10 hover:bg-white/20 text-sm"
+        >
+          Login with Basic
+        </button>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <p className={`text-center text-sm ${isDarkMode ? "text-slate-100" : "text-gray-700"}`}>
+        Could not load shared tasks.
+      </p>
+    );
+  }
+
+  if (mounts.length === 0) {
+    return (
+      <div className="text-center">
+        <p className={`text-lg font-bold ${isDarkMode ? "text-slate-100" : "text-gray-900"}`}>
+          Nothing shared with you yet
+        </p>
+        <p className={`no-task-blurb text-sm font-serif mt-2 ${isDarkMode ? "text-slate-100" : "text-gray-700"}`}>
+          Accept invites in Basic ID, then they’ll show up here.
+        </p>
+        <button
+          type="button"
+          onClick={() => { window.location.assign(manageUrl); }}
+          className="mt-4 text-sm underline opacity-80 hover:opacity-100"
+        >
+          Manage shares
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`flex flex-col ${viewMode === "compact" ? "space-y-4" : "space-y-6"}`}>
+      {mounts.map((mount) => (
+        <SharedMountTaskList
+          key={mount.id}
+          mountId={mount.id}
+          role={mount.role}
+          originOwnerDid={mount.originOwnerDid}
+          viewMode={viewMode}
+          isMobile={isMobile}
+          isDarkMode={isDarkMode}
+        />
+      ))}
+    </div>
+  );
+}
+
+function SharedMountTaskList({
+  mountId,
+  role,
+  originOwnerDid,
+  viewMode,
+  isMobile,
+  isDarkMode,
+}: {
+  mountId: string;
+  role: "viewer" | "editor";
+  originOwnerDid: string;
+  viewMode: "compact" | "cozy" | "chonky";
+  isMobile: boolean;
+  isDarkMode: boolean;
+}) {
+  const { data, isLoading, error } = basic.useQuery("tasks", undefined, { source: { mountId } });
+  const tasksTable = basic.useCollection("tasks", { source: { mountId } });
+  const tasks = useMemo(
+    () => unwrapTasks(data).filter((task) => !task.parentTaskId),
+    [data],
+  );
+
+  const updateTask = (id: string, changes: TaskUpdate) => {
+    if (role !== "editor") {
+      return;
+    }
+
+    void tasksTable.patch(id, changes);
+  };
+
+  const deleteTask = (id: string) => {
+    if (role !== "editor") {
+      return;
+    }
+
+    void tasksTable.delete(id);
+  };
+
+  const handleTaskSelect = () => {
+    // Shared tasks stay in this list for now; opening them in the island
+    // would write back to the local repo.
+  };
+
+  if (isLoading) {
+    return <p className="text-sm opacity-60">Loading shared tasks…</p>;
+  }
+
+  if (error || tasks.length === 0) {
+    return null;
+  }
+
+  return (
+    <div>
+      <p className={`text-xs uppercase tracking-wider mb-2 ${isDarkMode ? "text-gray-400" : "text-gray-600"}`}>
+        From {shortDid(originOwnerDid)} · {role}
+      </p>
+      <div className={`flex flex-col ${viewMode === "compact" ? "space-y-0" : viewMode === "cozy" ? "space-y-1" : "space-y-2"}`}>
+        {tasks.map((task) => (
+          <ListItem
+            key={`${mountId}:${task.id}`}
+            task={task}
+            updateTask={updateTask}
+            deleteTask={deleteTask}
+            handleTaskSelect={handleTaskSelect}
+            viewMode={viewMode}
+            isMobile={isMobile}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/TaskModal.tsx
+++ b/apps/web/src/components/TaskModal.tsx
@@ -6,6 +6,7 @@ import { ScheduleCardData, getTimeFromDateTime, getEventDuration } from '../util
 import { useTheme } from '../contexts/ThemeContext';
 import { useSubtaskRecords } from '../hooks/useBasicData';
 import SubtasksList from './SubtasksList';
+import TaskSharePanel from './TaskSharePanel';
 import { useAutoResizeTextarea } from '../hooks/useAutoResizeTextarea';
 import { showPickerOrClick } from '../utils/showPicker';
 
@@ -668,6 +669,9 @@ export const TaskModal = ({
           placeholder="Some description..."
           style={{ height: 'auto' }}
         />
+        {!isNew && task?.id ? (
+          <TaskSharePanel taskId={task.id} taskName={taskName || task.name} />
+        ) : null}
         </div>{/* End scrollable content area */}
         
         {/* Bottom Action Buttons - positioned at bottom, outside scroll */}

--- a/apps/web/src/components/TaskSharePanel.tsx
+++ b/apps/web/src/components/TaskSharePanel.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useTransition } from "react";
 import { basic } from "../basic";
-import { isOpenShare, resolveShareRecipient, shareIncludesTask, shortDid } from "../utils/shares";
+import { isOpenShare, resolveShareRecipient, shareErrorMessage, shareIncludesTask, shortDid } from "../utils/shares";
 
 interface TaskSharePanelProps {
   taskId: string;
@@ -35,7 +35,7 @@ export default function TaskSharePanel({ taskId, taskName, compact = false }: Ta
         setHandle("");
         shares.refresh();
       } catch (shareError) {
-        setError(shareError instanceof Error ? shareError.message : "Could not share this task.");
+        setError(shareErrorMessage(shareError));
       }
     });
   };

--- a/apps/web/src/components/TaskSharePanel.tsx
+++ b/apps/web/src/components/TaskSharePanel.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState, useTransition } from "react";
 import { basic } from "../basic";
-import { isOpenShare, normalizeShareHandle, shareIncludesTask, shortDid } from "../utils/shares";
+import { isOpenShare, resolveShareRecipient, shareIncludesTask, shortDid } from "../utils/shares";
 
 interface TaskSharePanelProps {
   taskId: string;
@@ -21,18 +21,13 @@ export default function TaskSharePanel({ taskId, taskName, compact = false }: Ta
   );
 
   const submitShare = () => {
-    const recipientHandle = normalizeShareHandle(handle);
-    if (!recipientHandle) {
-      setError("Enter a Basic handle.");
-      return;
-    }
-
     setError(null);
     startTransition(async () => {
       try {
+        const recipientDid = await resolveShareRecipient(handle);
         await shares.create({
           repo: "default",
-          recipientHandle,
+          recipientDid,
           role: "editor",
           scope: [{ table: "tasks", recordIds: [taskId] }],
           display: { shareName: taskName },

--- a/apps/web/src/components/TaskSharePanel.tsx
+++ b/apps/web/src/components/TaskSharePanel.tsx
@@ -1,0 +1,139 @@
+import { useMemo, useState, useTransition } from "react";
+import { basic } from "../basic";
+import { isOpenShare, normalizeShareHandle, shareIncludesTask, shortDid } from "../utils/shares";
+
+interface TaskSharePanelProps {
+  taskId: string;
+  taskName: string;
+  compact?: boolean;
+}
+
+export default function TaskSharePanel({ taskId, taskName, compact = false }: TaskSharePanelProps) {
+  const { isSignedIn, isReady, signIn } = basic.useAuth();
+  const shares = basic.useOutgoingShares();
+  const [handle, setHandle] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isPending, startTransition] = useTransition();
+
+  const taskShares = useMemo(
+    () => shares.outgoingShares.filter((share) => isOpenShare(share) && shareIncludesTask(share, taskId)),
+    [shares.outgoingShares, taskId],
+  );
+
+  const submitShare = () => {
+    const recipientHandle = normalizeShareHandle(handle);
+    if (!recipientHandle) {
+      setError("Enter a Basic handle.");
+      return;
+    }
+
+    setError(null);
+    startTransition(async () => {
+      try {
+        await shares.create({
+          repo: "default",
+          recipientHandle,
+          role: "editor",
+          scope: [{ table: "tasks", recordIds: [taskId] }],
+          display: { shareName: taskName },
+        });
+        setHandle("");
+        shares.refresh();
+      } catch (shareError) {
+        setError(shareError instanceof Error ? shareError.message : "Could not share this task.");
+      }
+    });
+  };
+
+  const endShare = (shareId: string, state: "pending" | "active") => {
+    startTransition(async () => {
+      try {
+        if (state === "pending") {
+          await shares.cancel(shareId);
+        } else {
+          await shares.revoke(shareId);
+        }
+        shares.refresh();
+      } catch (shareError) {
+        setError(shareError instanceof Error ? shareError.message : "Could not update this share.");
+      }
+    });
+  };
+
+  if (!isReady) {
+    return null;
+  }
+
+  if (!isSignedIn) {
+    return (
+      <div className={compact ? "pt-3" : "pt-4"}>
+        <p className="text-xs opacity-70 mb-2">Sign in to share this task with a friend.</p>
+        <button
+          type="button"
+          onClick={() => { void signIn(); }}
+          className="text-xs underline opacity-80 hover:opacity-100"
+        >
+          Login with Basic
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className={compact ? "pt-3 space-y-2" : "pt-4 space-y-3"}>
+      <p className="text-xs font-semibold uppercase tracking-wider opacity-60">Share</p>
+      <form
+        className="flex items-center gap-2"
+        onSubmit={(event) => {
+          event.preventDefault();
+          submitShare();
+        }}
+      >
+        <input
+          type="text"
+          value={handle}
+          onChange={(event) => setHandle(event.target.value)}
+          placeholder="friend.basic.id"
+          autoComplete="off"
+          className="flex-1 min-w-0 bg-white/5 border border-white/10 rounded-lg px-3 py-1.5 text-sm outline-none focus:ring-2 focus:ring-white/20"
+        />
+        <button
+          type="submit"
+          disabled={isPending || !handle.trim()}
+          className="px-3 py-1.5 rounded-lg text-sm bg-white/10 hover:bg-white/20 disabled:opacity-40"
+        >
+          {isPending ? "Sharing…" : "Share"}
+        </button>
+      </form>
+      {error ? <p className="text-xs text-red-300">{error}</p> : null}
+      {shares.error ? <p className="text-xs text-red-300">{shares.error.message}</p> : null}
+
+      {taskShares.length > 0 ? (
+        <ul className="space-y-1">
+          {taskShares.map((share) => (
+            <li key={share.id} className="flex items-center justify-between gap-2 text-xs opacity-80">
+              <span>
+                {shortDid(share.recipientDid)}
+                <span className="ml-2 uppercase tracking-wider opacity-60">{share.state}</span>
+              </span>
+              <button
+                type="button"
+                disabled={isPending}
+                onClick={() => {
+                  if (share.state === "pending" || share.state === "active") {
+                    endShare(share.id, share.state);
+                  }
+                }}
+                className="underline opacity-70 hover:opacity-100"
+              >
+                {share.state === "pending" ? "Cancel" : "Revoke"}
+              </button>
+            </li>
+          ))}
+        </ul>
+      ) : (
+        <p className="text-xs opacity-60">Not shared yet. They’ll get an invite in Basic ID.</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/hooks/useOpenedMounts.ts
+++ b/apps/web/src/hooks/useOpenedMounts.ts
@@ -54,6 +54,6 @@ export function useOpenedMounts() {
     isLoading: mounts.isLoading || pendingOpen,
     error: mounts.error,
     mounts: openedMounts,
-    manageUrl: mounts.manageUrl(),
+    manageUrl: "https://basic.id/shares",
   };
 }

--- a/apps/web/src/hooks/useOpenedMounts.ts
+++ b/apps/web/src/hooks/useOpenedMounts.ts
@@ -1,0 +1,59 @@
+import { useEffect, useRef, useState } from "react";
+import { basic } from "../basic";
+
+export function useOpenedMounts() {
+  const mounts = basic.useMounts();
+  const { isReady, isSignedIn } = basic.useAuth();
+  const [openedIds, setOpenedIds] = useState<string[]>([]);
+  const openingRef = useRef(new Set<string>());
+  const mountKey = mounts.mounts
+    .map((mount) => `${mount.id}:${mount.state}:${mount.originState}`)
+    .join("|");
+
+  useEffect(() => {
+    if (!isReady || !isSignedIn) {
+      openingRef.current.clear();
+      setOpenedIds([]);
+      return;
+    }
+
+    const eligible = mounts.mounts.filter(
+      (mount) => mount.state === "active" && mount.originState !== "ended",
+    );
+
+    for (const mount of eligible) {
+      if (openingRef.current.has(mount.id)) {
+        continue;
+      }
+
+      openingRef.current.add(mount.id);
+      void mounts.open(mount.id).then(
+        () => {
+          setOpenedIds((current) => (
+            current.includes(mount.id) ? current : [...current, mount.id]
+          ));
+        },
+        (error: unknown) => {
+          openingRef.current.delete(mount.id);
+          console.error("Failed to open shared mount", error);
+        },
+      );
+    }
+  }, [isReady, isSignedIn, mountKey, mounts]);
+
+  const openedMounts = mounts.mounts.filter((mount) => openedIds.includes(mount.id));
+  const pendingOpen = isSignedIn && mounts.mounts.some((mount) => (
+    mount.state === "active"
+    && mount.originState !== "ended"
+    && !openedIds.includes(mount.id)
+  ));
+
+  return {
+    isReady,
+    isSignedIn,
+    isLoading: mounts.isLoading || pendingOpen,
+    error: mounts.error,
+    mounts: openedMounts,
+    manageUrl: mounts.manageUrl(),
+  };
+}

--- a/apps/web/src/utils/shares.test.ts
+++ b/apps/web/src/utils/shares.test.ts
@@ -1,5 +1,5 @@
-import { describe, expect, it } from "vitest";
-import { isOpenShare, normalizeShareHandle, shareIncludesTask, shortDid } from "./shares";
+import { describe, expect, it, vi } from "vitest";
+import { isOpenShare, normalizeShareHandle, resolveShareRecipient, shareIncludesTask, shortDid } from "./shares";
 
 describe("normalizeShareHandle", () => {
   it("trims, lowercases, and adds .basic.id when needed", () => {
@@ -36,5 +36,30 @@ describe("shortDid", () => {
   it("shortens long DIDs", () => {
     expect(shortDid("did:web:fff.basic.id")).toBe("did:web:fff.basic.id");
     expect(shortDid("did:plc:abcdefghijklmnopqrstuvwxyz")).toBe("did:plc:ab…uvwxyz");
+  });
+});
+
+describe("resolveShareRecipient", () => {
+  it("returns a DID unchanged", async () => {
+    await expect(resolveShareRecipient("did:web:fff.basic.id")).resolves.toBe("did:web:fff.basic.id");
+  });
+
+  it("resolves a handle through the PDS", async () => {
+    const fetcher = vi.fn(async () => new Response(JSON.stringify({
+      did: "did:web:basicid.net:u:e32d5eb80402ae5e3ca83379",
+      handle: "fff.basic.id",
+    })));
+
+    await expect(resolveShareRecipient("fff", fetcher)).resolves.toBe(
+      "did:web:basicid.net:u:e32d5eb80402ae5e3ca83379",
+    );
+    expect(fetcher).toHaveBeenCalledWith(
+      "https://pds.basic.id/auth/handle/resolve?handle=fff.basic.id",
+    );
+  });
+
+  it("surfaces handle-not-found errors", async () => {
+    const fetcher = vi.fn(async () => new Response(JSON.stringify({ error: "Handle not found" }), { status: 404 }));
+    await expect(resolveShareRecipient("alice", fetcher)).rejects.toThrow("Handle not found");
   });
 });

--- a/apps/web/src/utils/shares.test.ts
+++ b/apps/web/src/utils/shares.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+import { isOpenShare, normalizeShareHandle, shareIncludesTask, shortDid } from "./shares";
+
+describe("normalizeShareHandle", () => {
+  it("trims, lowercases, and adds .basic.id when needed", () => {
+    expect(normalizeShareHandle("  @FFF  ")).toBe("fff.basic.id");
+    expect(normalizeShareHandle("alice.basic.id")).toBe("alice.basic.id");
+    expect(normalizeShareHandle("")).toBe("");
+  });
+});
+
+describe("shareIncludesTask", () => {
+  it("matches a task-scoped share", () => {
+    expect(shareIncludesTask({
+      scope: [{ table: "tasks", recordIds: ["task-1"] }],
+    }, "task-1")).toBe(true);
+    expect(shareIncludesTask({
+      scope: [{ table: "tasks", recordIds: ["task-2"] }],
+    }, "task-1")).toBe(false);
+  });
+
+  it("treats a whole-table tasks share as including the task", () => {
+    expect(shareIncludesTask({ scope: [{ table: "tasks" }] }, "task-1")).toBe(true);
+  });
+});
+
+describe("isOpenShare", () => {
+  it("keeps pending and active shares", () => {
+    expect(isOpenShare({ state: "pending" })).toBe(true);
+    expect(isOpenShare({ state: "active" })).toBe(true);
+    expect(isOpenShare({ state: "ended" })).toBe(false);
+  });
+});
+
+describe("shortDid", () => {
+  it("shortens long DIDs", () => {
+    expect(shortDid("did:web:fff.basic.id")).toBe("did:web:fff.basic.id");
+    expect(shortDid("did:plc:abcdefghijklmnopqrstuvwxyz")).toBe("did:plc:ab…uvwxyz");
+  });
+});

--- a/apps/web/src/utils/shares.test.ts
+++ b/apps/web/src/utils/shares.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { isOpenShare, normalizeShareHandle, resolveShareRecipient, shareIncludesTask, shortDid } from "./shares";
+import { isOpenShare, normalizeShareHandle, resolveShareRecipient, shareErrorMessage, shareIncludesTask, shortDid } from "./shares";
 
 describe("normalizeShareHandle", () => {
   it("trims, lowercases, and adds .basic.id when needed", () => {
@@ -36,6 +36,14 @@ describe("shortDid", () => {
   it("shortens long DIDs", () => {
     expect(shortDid("did:web:fff.basic.id")).toBe("did:web:fff.basic.id");
     expect(shortDid("did:plc:abcdefghijklmnopqrstuvwxyz")).toBe("did:plc:ab…uvwxyz");
+  });
+});
+
+describe("shareErrorMessage", () => {
+  it("explains a non-schema origin repo", () => {
+    expect(shareErrorMessage(new Error("origin must be an active basic-schema repo"))).toMatch(
+      /older repo type/,
+    );
   });
 });
 

--- a/apps/web/src/utils/shares.ts
+++ b/apps/web/src/utils/shares.ts
@@ -1,5 +1,7 @@
 import type { OutgoingShareInfo } from "@basictech/core";
 
+const HANDLE_RESOLVE_ORIGIN = "https://pds.basic.id";
+
 export function normalizeShareHandle(input: string) {
   const trimmed = input.trim().toLowerCase().replace(/^@/, "");
   if (!trimmed) {
@@ -29,4 +31,29 @@ export function shortDid(did: string) {
   }
 
   return `${did.slice(0, 10)}…${did.slice(-6)}`;
+}
+
+export async function resolveShareRecipient(
+  input: string,
+  fetcher: typeof fetch = globalThis.fetch.bind(globalThis),
+) {
+  const trimmed = input.trim();
+  if (trimmed.startsWith("did:")) {
+    return trimmed;
+  }
+
+  const handle = normalizeShareHandle(trimmed);
+  if (!handle) {
+    throw new Error("Enter a Basic handle.");
+  }
+
+  const response = await fetcher(
+    `${HANDLE_RESOLVE_ORIGIN}/auth/handle/resolve?handle=${encodeURIComponent(handle)}`,
+  );
+  const body = await response.json().catch(() => ({} as { did?: unknown; error?: unknown }));
+  if (!response.ok || typeof body.did !== "string") {
+    throw new Error(typeof body.error === "string" ? body.error : "Handle not found");
+  }
+
+  return body.did;
 }

--- a/apps/web/src/utils/shares.ts
+++ b/apps/web/src/utils/shares.ts
@@ -33,6 +33,15 @@ export function shortDid(did: string) {
   return `${did.slice(0, 10)}…${did.slice(-6)}`;
 }
 
+export function shareErrorMessage(error: unknown) {
+  const message = error instanceof Error ? error.message : "Could not share this task.";
+  if (message.toLowerCase().includes("basic-schema")) {
+    return "Sharing needs a Basic schema library. This account’s tasks are still on the older repo type.";
+  }
+
+  return message;
+}
+
 export async function resolveShareRecipient(
   input: string,
   fetcher: typeof fetch = globalThis.fetch.bind(globalThis),

--- a/apps/web/src/utils/shares.ts
+++ b/apps/web/src/utils/shares.ts
@@ -1,0 +1,32 @@
+import type { OutgoingShareInfo } from "@basictech/core";
+
+export function normalizeShareHandle(input: string) {
+  const trimmed = input.trim().toLowerCase().replace(/^@/, "");
+  if (!trimmed) {
+    return "";
+  }
+
+  return trimmed.includes(".") ? trimmed : `${trimmed}.basic.id`;
+}
+
+export function shareIncludesTask(share: Pick<OutgoingShareInfo, "scope">, taskId: string) {
+  return share.scope.some((clause) => {
+    if (clause.table !== "tasks") {
+      return false;
+    }
+
+    return !clause.recordIds || clause.recordIds.includes(taskId);
+  });
+}
+
+export function isOpenShare(share: Pick<OutgoingShareInfo, "state">) {
+  return share.state === "pending" || share.state === "active";
+}
+
+export function shortDid(did: string) {
+  if (did.length <= 20) {
+    return did;
+  }
+
+  return `${did.slice(0, 10)}…${did.slice(-6)}`;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds first-pass task sharing on Basic 0.11 Shares v2.

## What changed
- Share a single task from task details by Basic handle (`friend` or `friend.basic.id`)
- List and cancel/revoke that task’s outgoing shares
- New **Shared** folder for incoming mounts
- Settings link to manage shares in Basic ID

## CORS
Confirmed `pds.basic.id` now returns `Access-Control-Allow-Origin: *` on well-known, preflight, and `/api/v1` routes.

## Verification
- Unit tests and lint
- Manual: login, open a task, share panel, Shared folder

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fb9627c-db98-4e4d-84e5-fc1e233d7152?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fb9627c-db98-4e4d-84e5-fc1e233d7152&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

