### PR TITLE
Show sync status and schema info in the profile popup

### DIFF
--- a/apps/web/src/basic.ts
+++ b/apps/web/src/basic.ts
@@ -6,6 +6,8 @@ export { schema };
 
 const DEFAULT_CLIENT_ID = "did:web:tsk.lol";
 
+export const BASIC_CLIENT_ID = import.meta.env.VITE_BASIC_CLIENT_ID || DEFAULT_CLIENT_ID;
+
 function createBasicFetch(): typeof fetch {
   const browserFetch = globalThis.fetch.bind(globalThis);
 
@@ -47,7 +49,7 @@ function createBasicWebSocket() {
 
 export const basic = createBasic({
   schema,
-  clientId: import.meta.env.VITE_BASIC_CLIENT_ID || DEFAULT_CLIENT_ID,
+  clientId: BASIC_CLIENT_ID,
   debug: import.meta.env.DEV,
   allowInsecure: import.meta.env.DEV,
   fetch: createBasicFetch(),

--- a/apps/web/src/components/TaskSharePanel.tsx
+++ b/apps/web/src/components/TaskSharePanel.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState, useTransition } from "react";
 import { basic } from "../basic";
+import { defaultRepoType } from "../utils/schemaInfo";
 import { isOpenShare, resolveShareRecipient, shareErrorMessage, shareIncludesTask, shortDid } from "../utils/shares";
 
 interface TaskSharePanelProps {
@@ -10,7 +11,10 @@ interface TaskSharePanelProps {
 
 export default function TaskSharePanel({ taskId, taskName, compact = false }: TaskSharePanelProps) {
   const { isSignedIn, isReady, signIn } = basic.useAuth();
+  const schemaStatus = basic.useSchemaStatus();
+  const { repos, defaultRepoId } = basic.useRepos();
   const shares = basic.useOutgoingShares();
+  const repoType = defaultRepoType(repos, defaultRepoId) ?? schemaStatus.mode;
   const [handle, setHandle] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();
@@ -35,7 +39,7 @@ export default function TaskSharePanel({ taskId, taskName, compact = false }: Ta
         setHandle("");
         shares.refresh();
       } catch (shareError) {
-        setError(shareErrorMessage(shareError));
+        setError(shareErrorMessage(shareError, repoType));
       }
     });
   };
@@ -100,6 +104,11 @@ export default function TaskSharePanel({ taskId, taskName, compact = false }: Ta
           {isPending ? "Sharing…" : "Share"}
         </button>
       </form>
+      {repoType && repoType !== "basic-schema" && repoType !== "unknown" ? (
+        <p className="text-xs text-amber-200/90">
+          Sharing needs a Basic schema library. This account’s tasks are still on the {repoType} repo type.
+        </p>
+      ) : null}
       {error ? <p className="text-xs text-red-300">{error}</p> : null}
       {shares.error ? <p className="text-xs text-red-300">{shares.error.message}</p> : null}
 

--- a/apps/web/src/components/TaskSharePanel.tsx
+++ b/apps/web/src/components/TaskSharePanel.tsx
@@ -11,10 +11,9 @@ interface TaskSharePanelProps {
 
 export default function TaskSharePanel({ taskId, taskName, compact = false }: TaskSharePanelProps) {
   const { isSignedIn, isReady, signIn } = basic.useAuth();
-  const schemaStatus = basic.useSchemaStatus();
-  const { repos, defaultRepoId } = basic.useRepos();
+  const { repos } = basic.useBasic();
   const shares = basic.useOutgoingShares();
-  const repoType = defaultRepoType(repos, defaultRepoId) ?? schemaStatus.mode;
+  const repoType = defaultRepoType(repos);
   const [handle, setHandle] = useState("");
   const [error, setError] = useState<string | null>(null);
   const [isPending, startTransition] = useTransition();

--- a/apps/web/src/components/UserAvatarButton.tsx
+++ b/apps/web/src/components/UserAvatarButton.tsx
@@ -2,14 +2,13 @@ import { useState } from "react";
 import { BASIC_CLIENT_ID, basic, schema } from "../basic";
 import * as Popover from '@radix-ui/react-popover';
 import packageJson from '../../package.json';
-import { defaultRepoType, getSchemaInfoDisplay } from "../utils/schemaInfo";
+import { defaultRepoType, findDefaultRepo, getSchemaInfoDisplay } from "../utils/schemaInfo";
 import { getSyncStatusDisplay } from "../utils/syncStatus";
 
 function UserAvatarButton() {
-  const { signIn, signOut, isSignedIn, user, isReady, sync, status } = basic.useBasic();
-  const schemaStatus = basic.useSchemaStatus();
-  const { repos, defaultRepoId } = basic.useRepos();
+  const { signIn, signOut, isSignedIn, user, isReady, sync, status, repos } = basic.useBasic();
   const [hasNotifications] = useState(true);
+  const defaultRepo = findDefaultRepo(repos);
   const syncDisplay = getSyncStatusDisplay({
     isSignedIn,
     authStatus: status,
@@ -19,10 +18,10 @@ function UserAvatarButton() {
   const schemaInfo = getSchemaInfoDisplay({
     projectId: schema.project_id,
     clientId: BASIC_CLIENT_ID,
-    localVersion: schemaStatus.localVersion ?? schema.version,
-    mode: schemaStatus.mode,
-    serverVersion: schemaStatus.serverVersion,
-    defaultRepoSchemaType: defaultRepoType(repos, defaultRepoId),
+    localVersion: schema.version,
+    mode: defaultRepo?.schema_type,
+    serverVersion: defaultRepo?.schema_version,
+    defaultRepoSchemaType: defaultRepoType(repos),
   });
 
   const handleLogin = () => {

--- a/apps/web/src/components/UserAvatarButton.tsx
+++ b/apps/web/src/components/UserAvatarButton.tsx
@@ -1,11 +1,29 @@
 import { useState } from "react";
-import { basic } from "../basic";
+import { BASIC_CLIENT_ID, basic, schema } from "../basic";
 import * as Popover from '@radix-ui/react-popover';
 import packageJson from '../../package.json';
+import { defaultRepoType, getSchemaInfoDisplay } from "../utils/schemaInfo";
+import { getSyncStatusDisplay } from "../utils/syncStatus";
 
 function UserAvatarButton() {
   const { signIn, signOut, isSignedIn, user, isReady, sync, status } = basic.useBasic();
+  const schemaStatus = basic.useSchemaStatus();
+  const { repos, defaultRepoId } = basic.useRepos();
   const [hasNotifications] = useState(true);
+  const syncDisplay = getSyncStatusDisplay({
+    isSignedIn,
+    authStatus: status,
+    syncStatus: sync.status,
+    pendingCount: sync.pendingCount,
+  });
+  const schemaInfo = getSchemaInfoDisplay({
+    projectId: schema.project_id,
+    clientId: BASIC_CLIENT_ID,
+    localVersion: schemaStatus.localVersion ?? schema.version,
+    mode: schemaStatus.mode,
+    serverVersion: schemaStatus.serverVersion,
+    defaultRepoSchemaType: defaultRepoType(repos, defaultRepoId),
+  });
 
   const handleLogin = () => {
     void signIn().catch((error) => {
@@ -60,7 +78,7 @@ function UserAvatarButton() {
       </Popover.Trigger>
       <Popover.Portal>
         <Popover.Content
-          className="shadow-lg w-64 bg-[#1F1B2F] rounded-lg"
+          className="shadow-lg w-72 bg-[#1F1B2F] rounded-lg"
           sideOffset={5}
           align="end"
         >
@@ -73,6 +91,26 @@ function UserAvatarButton() {
                 {user?.handle && (
                   <p className="text-gray-400 text-sm mt-0.5">@{user.handle}</p>
                 )}
+
+                <div className="border-t border-gray-600 my-4"></div>
+
+                <div className="text-xs text-gray-300 space-y-1">
+                  <p className="uppercase tracking-wider text-gray-400">Sync</p>
+                  <p className="text-slate-100">{syncDisplay.label}</p>
+                  <p className="text-gray-400">{syncDisplay.detail}</p>
+                </div>
+
+                <div className="border-t border-gray-600 my-4"></div>
+
+                <div className="text-xs text-gray-300 font-mono space-y-1">
+                  <p className="uppercase tracking-wider text-gray-400 font-sans">Schema</p>
+                  <div>{schemaInfo.summary}</div>
+                  <div title={schemaInfo.projectId}>project {schemaInfo.projectId}</div>
+                  <div title={schemaInfo.clientId}>client {schemaInfo.clientId}</div>
+                  {schemaInfo.shareHint ? (
+                    <p className="font-sans text-amber-200/90 pt-1">{schemaInfo.shareHint}</p>
+                  ) : null}
+                </div>
 
                 <div className="border-t border-gray-600 my-4"></div>
 
@@ -96,6 +134,12 @@ function UserAvatarButton() {
                 <p className="text-gray-200"> - backup your tasks</p>
 
                 <div className="border-t border-gray-600 my-4"></div>
+
+                <div className="text-xs text-gray-300 space-y-1 mb-4">
+                  <p className="uppercase tracking-wider text-gray-400">Sync</p>
+                  <p className="text-slate-100">{syncDisplay.label}</p>
+                  <p className="text-gray-400">{syncDisplay.detail}</p>
+                </div>
 
 
                 <button

--- a/apps/web/src/utils/schemaInfo.test.ts
+++ b/apps/web/src/utils/schemaInfo.test.ts
@@ -1,5 +1,13 @@
 import { describe, expect, it } from "vitest";
-import { canShareFromRepoType, defaultRepoType, getSchemaInfoDisplay } from "./schemaInfo";
+import { canShareFromRepoType, defaultRepoType, findDefaultRepo, getSchemaInfoDisplay } from "./schemaInfo";
+
+describe("findDefaultRepo", () => {
+  it("falls back to the first repo when none is marked default", () => {
+    expect(findDefaultRepo([
+      { id: "only", schema_type: "freeform" },
+    ])?.id).toBe("only");
+  });
+});
 
 describe("defaultRepoType", () => {
   it("prefers the catalog default repo id", () => {

--- a/apps/web/src/utils/schemaInfo.test.ts
+++ b/apps/web/src/utils/schemaInfo.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { canShareFromRepoType, defaultRepoType, getSchemaInfoDisplay } from "./schemaInfo";
+
+describe("defaultRepoType", () => {
+  it("prefers the catalog default repo id", () => {
+    expect(defaultRepoType([
+      { id: "old", schema_type: "freeform", access: { is_default: true } },
+      { id: "new", schema_type: "basic-schema" },
+    ], "new")).toBe("basic-schema");
+  });
+
+  it("falls back to the marked default repo", () => {
+    expect(defaultRepoType([
+      { id: "old", schema_type: "dynamic", access: { is_default: true } },
+    ], null)).toBe("dynamic");
+  });
+});
+
+describe("canShareFromRepoType", () => {
+  it("only allows basic-schema origins", () => {
+    expect(canShareFromRepoType("basic-schema")).toBe(true);
+    expect(canShareFromRepoType("dynamic")).toBe(false);
+    expect(canShareFromRepoType("freeform")).toBe(false);
+    expect(canShareFromRepoType(null)).toBe(false);
+  });
+});
+
+describe("getSchemaInfoDisplay", () => {
+  it("summarizes local and server versions", () => {
+    const info = getSchemaInfoDisplay({
+      projectId: "701b11bc-59a8-45b5-8148-7184d7733e5b",
+      clientId: "did:web:tsk.lol",
+      localVersion: 6,
+      mode: "dynamic",
+      serverVersion: 1,
+      defaultRepoSchemaType: "dynamic",
+    });
+
+    expect(info.summary).toBe("dynamic · app v6 · server v1");
+    expect(info.canShare).toBe(false);
+    expect(info.shareHint).toMatch(/older type/);
+  });
+
+  it("marks a basic-schema repo as shareable", () => {
+    const info = getSchemaInfoDisplay({
+      projectId: "701b11bc-59a8-45b5-8148-7184d7733e5b",
+      clientId: "did:web:tsk.lol",
+      localVersion: 6,
+      mode: "basic-schema",
+      serverVersion: 6,
+    });
+
+    expect(info.canShare).toBe(true);
+    expect(info.shareHint).toBeUndefined();
+  });
+});

--- a/apps/web/src/utils/schemaInfo.ts
+++ b/apps/web/src/utils/schemaInfo.ts
@@ -1,12 +1,20 @@
 export const SHAREABLE_REPO_TYPE = "basic-schema";
 
+export function findDefaultRepo<T extends { id: string; access?: { is_default?: boolean } }>(
+  repos: T[],
+  defaultRepoId?: string | null,
+) {
+  return repos.find((repo) => repo.id === defaultRepoId)
+    ?? repos.find((repo) => repo.access?.is_default)
+    ?? repos[0]
+    ?? null;
+}
+
 export function defaultRepoType(
   repos: Array<{ id: string; schema_type?: string; access?: { is_default?: boolean } }>,
   defaultRepoId?: string | null,
 ) {
-  const matched = repos.find((repo) => repo.id === defaultRepoId)
-    ?? repos.find((repo) => repo.access?.is_default);
-  return matched?.schema_type ?? null;
+  return findDefaultRepo(repos, defaultRepoId)?.schema_type ?? null;
 }
 
 export function canShareFromRepoType(repoType: string | null | undefined) {

--- a/apps/web/src/utils/schemaInfo.ts
+++ b/apps/web/src/utils/schemaInfo.ts
@@ -1,0 +1,49 @@
+export const SHAREABLE_REPO_TYPE = "basic-schema";
+
+export function defaultRepoType(
+  repos: Array<{ id: string; schema_type?: string; access?: { is_default?: boolean } }>,
+  defaultRepoId?: string | null,
+) {
+  const matched = repos.find((repo) => repo.id === defaultRepoId)
+    ?? repos.find((repo) => repo.access?.is_default);
+  return matched?.schema_type ?? null;
+}
+
+export function canShareFromRepoType(repoType: string | null | undefined) {
+  return repoType === SHAREABLE_REPO_TYPE;
+}
+
+export function getSchemaInfoDisplay({
+  projectId,
+  clientId,
+  localVersion,
+  mode,
+  serverVersion,
+  defaultRepoSchemaType,
+}: {
+  projectId: string;
+  clientId: string;
+  localVersion?: number;
+  mode?: string;
+  serverVersion?: number;
+  defaultRepoSchemaType?: string | null;
+}) {
+  const repoType = defaultRepoSchemaType
+    ?? (mode && mode !== "unknown" ? mode : null)
+    ?? "unknown";
+  const versionBits = [
+    localVersion != null ? `app v${localVersion}` : null,
+    serverVersion != null ? `server v${serverVersion}` : null,
+  ].filter((bit): bit is string => Boolean(bit));
+
+  return {
+    repoType,
+    canShare: canShareFromRepoType(repoType),
+    summary: versionBits.length > 0 ? `${repoType} · ${versionBits.join(" · ")}` : repoType,
+    projectId,
+    clientId,
+    shareHint: canShareFromRepoType(repoType)
+      ? undefined
+      : "Sharing needs a basic-schema repo. This account is still on the older type.",
+  };
+}

--- a/apps/web/src/utils/shares.test.ts
+++ b/apps/web/src/utils/shares.test.ts
@@ -45,6 +45,12 @@ describe("shareErrorMessage", () => {
       /older repo type/,
     );
   });
+
+  it("includes the live repo type when known", () => {
+    expect(shareErrorMessage(new Error("origin must be an active basic-schema repo"), "dynamic")).toMatch(
+      /dynamic repo type/,
+    );
+  });
 });
 
 describe("resolveShareRecipient", () => {

--- a/apps/web/src/utils/shares.ts
+++ b/apps/web/src/utils/shares.ts
@@ -33,10 +33,13 @@ export function shortDid(did: string) {
   return `${did.slice(0, 10)}…${did.slice(-6)}`;
 }
 
-export function shareErrorMessage(error: unknown) {
+export function shareErrorMessage(error: unknown, repoType?: string | null) {
   const message = error instanceof Error ? error.message : "Could not share this task.";
-  if (message.toLowerCase().includes("basic-schema")) {
-    return "Sharing needs a Basic schema library. This account’s tasks are still on the older repo type.";
+  const knownType = repoType && repoType !== "unknown" ? repoType : null;
+  if (message.toLowerCase().includes("basic-schema") || (knownType && knownType !== "basic-schema")) {
+    return knownType
+      ? `Sharing needs a Basic schema library. This account’s tasks are still on the ${knownType} repo type.`
+      : "Sharing needs a Basic schema library. This account’s tasks are still on the older repo type.";
   }
 
   return message;

--- a/apps/web/src/utils/syncStatus.test.ts
+++ b/apps/web/src/utils/syncStatus.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { getSyncStatusDisplay } from "./syncStatus";
+
+describe("getSyncStatusDisplay", () => {
+  it("shows local-only when signed out", () => {
+    expect(getSyncStatusDisplay({
+      isSignedIn: false,
+      syncStatus: "local",
+      pendingCount: 0,
+    })).toMatchObject({
+      label: "Local only",
+      tone: "neutral",
+    });
+  });
+
+  it("asks for sign-in when reauth is required", () => {
+    expect(getSyncStatusDisplay({
+      isSignedIn: true,
+      authStatus: "reauth_required",
+      syncStatus: "error",
+      pendingCount: 0,
+    }).label).toBe("Needs sign-in");
+  });
+
+  it("shows online with a pending count", () => {
+    expect(getSyncStatusDisplay({
+      isSignedIn: true,
+      syncStatus: "online",
+      pendingCount: 2,
+    })).toMatchObject({
+      label: "Online",
+      detail: "2 changes syncing.",
+      tone: "pending",
+    });
+  });
+
+  it("shows offline waiting changes", () => {
+    expect(getSyncStatusDisplay({
+      isSignedIn: true,
+      syncStatus: "offline",
+      pendingCount: 1,
+    })).toMatchObject({
+      label: "Offline",
+      detail: "1 change is waiting to sync.",
+      tone: "warn",
+    });
+  });
+
+  it("treats connecting states as pending", () => {
+    expect(getSyncStatusDisplay({
+      isSignedIn: true,
+      syncStatus: "bootstrapping",
+      pendingCount: 0,
+    }).label).toBe("Connecting");
+  });
+});

--- a/apps/web/src/utils/syncStatus.ts
+++ b/apps/web/src/utils/syncStatus.ts
@@ -1,0 +1,99 @@
+export type SyncStatusTone = "good" | "warn" | "pending" | "neutral" | "error";
+
+export interface SyncStatusDisplay {
+  label: string;
+  detail: string;
+  tone: SyncStatusTone;
+}
+
+function pendingDetail(pendingCount: number, waiting: boolean) {
+  if (pendingCount <= 0) {
+    return null;
+  }
+
+  const noun = pendingCount === 1 ? "change" : "changes";
+  if (waiting) {
+    return `${pendingCount} ${pendingCount === 1 ? "change is" : "changes are"} waiting to sync.`;
+  }
+
+  return `${pendingCount} ${noun} syncing.`;
+}
+
+export function getSyncStatusDisplay({
+  isSignedIn,
+  authStatus,
+  syncStatus,
+  pendingCount,
+}: {
+  isSignedIn: boolean;
+  authStatus?: string;
+  syncStatus: string | undefined;
+  pendingCount: number;
+}): SyncStatusDisplay {
+  if (!isSignedIn) {
+    return {
+      label: "Local only",
+      detail: "Tasks stay in this browser.",
+      tone: "neutral",
+    };
+  }
+
+  if (authStatus === "reauth_required") {
+    return {
+      label: "Needs sign-in",
+      detail: "Sign in again to resume sync.",
+      tone: "warn",
+    };
+  }
+
+  if (syncStatus === "error") {
+    return {
+      label: "Sync error",
+      detail: pendingDetail(pendingCount, true) ?? "Could not reach Basic.",
+      tone: "error",
+    };
+  }
+
+  if (syncStatus === "offline" || syncStatus === "ended") {
+    return {
+      label: "Offline",
+      detail: pendingDetail(pendingCount, true) ?? "Changes stay on this device until you are back online.",
+      tone: "warn",
+    };
+  }
+
+  if (syncStatus === "online") {
+    return {
+      label: "Online",
+      detail: pendingDetail(pendingCount, false) ?? "Synced with Basic.",
+      tone: pendingCount > 0 ? "pending" : "good",
+    };
+  }
+
+  if (
+    syncStatus === "connecting"
+    || syncStatus === "idle"
+    || syncStatus === "bootstrapping"
+    || !syncStatus
+  ) {
+    return {
+      label: "Connecting",
+      detail: "Checking sync…",
+      tone: "pending",
+    };
+  }
+
+  if (syncStatus === "stopped") {
+    return {
+      label: "Stopped",
+      detail: "Sync is not running.",
+      tone: "warn",
+    };
+  }
+
+  return {
+    label: "On this device",
+    detail: "Using the local copy of your tasks.",
+    tone: "neutral",
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
The share error `Sharing needs a Basic schema library. This account’s tasks are still on the older repo type.` is a server 422: the signed-in account’s **default repo** is not `basic-schema` (it’s still `dynamic` / `freeform` from the older 0.9 project).

This PR makes that visible in the product:

- Profile popup now shows **sync status** (Online / Offline / Connecting / Local only / Needs sign-in, plus pending count)
- When signed in, it also shows the live **schema / repo** values the app is using
- Share panel and share errors include the actual repo type when known (`dynamic`, `freeform`, etc.)

## What info the app uses
These are **not invented at share time**. They come from local config plus the Basic client snapshot:

| Value | Source | Used for |
|---|---|---|
| `project_id` `701b11bc-59a8-45b5-8148-7184d7733e5b` | `apps/web/basic.config.ts` (`defineSchema`) | Local schema identity / TypeScript inference. **Not** sent as share `app_id`. |
| schema `version` `6` | same file | Local schema version (`useSchemaStatus().localVersion`) |
| `clientId` `did:web:tsk.lol` | `createBasic({ clientId })` | OAuth + share `app_id` |
| share `repo: "default"` | `TaskSharePanel` | Origin is the account’s catalog default repo |
| server `schema_type` | `useRepos()` / `useSchemaStatus()` | Must be `basic-schema` for Shares v2 |

Creating a new empty `basic-schema` repo would not include existing task IDs, so the app does not do that. Unblocking share needs the **default repo on the PDS** upgraded to `basic-schema`.

## Test plan
- Unit tests for sync/schema helpers and share error copy
- Manual: open profile popup signed out (Local only) and signed in (sync + schema rows)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fb9627c-db98-4e4d-84e5-fc1e233d7152?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fb9627c-db98-4e4d-84e5-fc1e233d7152&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

