### PR TITLE
Use the Basic project DID as schema project_id

### DIFF
--- a/apps/web/basic.config.ts
+++ b/apps/web/basic.config.ts
@@ -2,13 +2,15 @@ import { defineSchema } from "@basictech/schema/define";
 
 // Basic Project Configuration
 // see the docs for more info: https://docs.basic.tech
+export const PROJECT_ID = "did:web:api.basic.tech:projects:701b11bc59a845b581487184d7733e5b";
+
 export const config = {
 	name: "tsk.lol",
-	project_id: "701b11bc-59a8-45b5-8148-7184d7733e5b",
+	project_id: PROJECT_ID,
 };
 
 export const schema = defineSchema({
-	project_id: "701b11bc-59a8-45b5-8148-7184d7733e5b",
+	project_id: PROJECT_ID,
 	version: 6,
 	tables: {
 		tasks: {

--- a/apps/web/src/components/UserAvatarButton.tsx
+++ b/apps/web/src/components/UserAvatarButton.tsx
@@ -104,7 +104,7 @@ function UserAvatarButton() {
                 <div className="text-xs text-gray-300 font-mono space-y-1">
                   <p className="uppercase tracking-wider text-gray-400 font-sans">Schema</p>
                   <div>{schemaInfo.summary}</div>
-                  <div title={schemaInfo.projectId}>project {schemaInfo.projectId}</div>
+                  <div className="break-all" title={schemaInfo.projectId}>project {schemaInfo.projectId}</div>
                   <div title={schemaInfo.clientId}>client {schemaInfo.clientId}</div>
                   {schemaInfo.shareHint ? (
                     <p className="font-sans text-amber-200/90 pt-1">{schemaInfo.shareHint}</p>

--- a/apps/web/src/utils/schemaInfo.test.ts
+++ b/apps/web/src/utils/schemaInfo.test.ts
@@ -36,7 +36,7 @@ describe("canShareFromRepoType", () => {
 describe("getSchemaInfoDisplay", () => {
   it("summarizes local and server versions", () => {
     const info = getSchemaInfoDisplay({
-      projectId: "701b11bc-59a8-45b5-8148-7184d7733e5b",
+      projectId: "did:web:api.basic.tech:projects:701b11bc59a845b581487184d7733e5b",
       clientId: "did:web:tsk.lol",
       localVersion: 6,
       mode: "dynamic",
@@ -51,7 +51,7 @@ describe("getSchemaInfoDisplay", () => {
 
   it("marks a basic-schema repo as shareable", () => {
     const info = getSchemaInfoDisplay({
-      projectId: "701b11bc-59a8-45b5-8148-7184d7733e5b",
+      projectId: "did:web:api.basic.tech:projects:701b11bc59a845b581487184d7733e5b",
       clientId: "did:web:tsk.lol",
       localVersion: 6,
       mode: "basic-schema",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
Point the local Basic schema at the project DID:

`did:web:api.basic.tech:projects:701b11bc59a845b581487184d7733e5b`

This replaces the hyphenated UUID `701b11bc-59a8-45b5-8148-7184d7733e5b` in `basic.config.ts` (`config.project_id` and `defineSchema({ project_id })`). The profile popup wraps the longer id.

## Why
Shares / schema library identity should use the Basic project DID, not the older UUID form.

## Test plan
- Unit tests for schema display
- Profile popup shows the new project id when signed in

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fb9627c-db98-4e4d-84e5-fc1e233d7152?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fb9627c-db98-4e4d-84e5-fc1e233d7152&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

