### PR TITLE
Use the project DID as the Basic client id

### DIFF
--- a/apps/web/src/basic.identity.test.ts
+++ b/apps/web/src/basic.identity.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, it } from "vitest";
+import { PROJECT_ID, schema } from "../basic.config";
+import { BASIC_CLIENT_ID } from "./basic";
+
+describe("Basic project identity", () => {
+  it("uses the project DID as the client id", () => {
+    expect(schema.project_id).toBe(PROJECT_ID);
+    expect(BASIC_CLIENT_ID).toBe(PROJECT_ID);
+    expect(PROJECT_ID).toBe("did:web:api.basic.tech:projects:701b11bc59a845b581487184d7733e5b");
+  });
+});

--- a/apps/web/src/basic.ts
+++ b/apps/web/src/basic.ts
@@ -1,12 +1,10 @@
 import { createBasic } from "@basictech/react";
-import { schema } from "../basic.config";
+import { PROJECT_ID, schema } from "../basic.config";
 import { rewriteBasicDevUrl } from "./basicDevProxy";
 
-export { schema };
+export { PROJECT_ID, schema };
 
-const DEFAULT_CLIENT_ID = "did:web:tsk.lol";
-
-export const BASIC_CLIENT_ID = import.meta.env.VITE_BASIC_CLIENT_ID || DEFAULT_CLIENT_ID;
+export const BASIC_CLIENT_ID = PROJECT_ID;
 
 function createBasicFetch(): typeof fetch {
   const browserFetch = globalThis.fetch.bind(globalThis);

--- a/apps/web/src/components/UserAvatarButton.tsx
+++ b/apps/web/src/components/UserAvatarButton.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { BASIC_CLIENT_ID, basic, schema } from "../basic";
+import { basic, schema } from "../basic";
 import * as Popover from '@radix-ui/react-popover';
 import packageJson from '../../package.json';
 import { defaultRepoType, findDefaultRepo, getSchemaInfoDisplay } from "../utils/schemaInfo";
@@ -17,7 +17,6 @@ function UserAvatarButton() {
   });
   const schemaInfo = getSchemaInfoDisplay({
     projectId: schema.project_id,
-    clientId: BASIC_CLIENT_ID,
     localVersion: schema.version,
     mode: defaultRepo?.schema_type,
     serverVersion: defaultRepo?.schema_version,
@@ -105,7 +104,6 @@ function UserAvatarButton() {
                   <p className="uppercase tracking-wider text-gray-400 font-sans">Schema</p>
                   <div>{schemaInfo.summary}</div>
                   <div className="break-all" title={schemaInfo.projectId}>project {schemaInfo.projectId}</div>
-                  <div title={schemaInfo.clientId}>client {schemaInfo.clientId}</div>
                   {schemaInfo.shareHint ? (
                     <p className="font-sans text-amber-200/90 pt-1">{schemaInfo.shareHint}</p>
                   ) : null}

--- a/apps/web/src/utils/schemaInfo.test.ts
+++ b/apps/web/src/utils/schemaInfo.test.ts
@@ -37,7 +37,6 @@ describe("getSchemaInfoDisplay", () => {
   it("summarizes local and server versions", () => {
     const info = getSchemaInfoDisplay({
       projectId: "did:web:api.basic.tech:projects:701b11bc59a845b581487184d7733e5b",
-      clientId: "did:web:tsk.lol",
       localVersion: 6,
       mode: "dynamic",
       serverVersion: 1,
@@ -52,7 +51,6 @@ describe("getSchemaInfoDisplay", () => {
   it("marks a basic-schema repo as shareable", () => {
     const info = getSchemaInfoDisplay({
       projectId: "did:web:api.basic.tech:projects:701b11bc59a845b581487184d7733e5b",
-      clientId: "did:web:tsk.lol",
       localVersion: 6,
       mode: "basic-schema",
       serverVersion: 6,

--- a/apps/web/src/utils/schemaInfo.ts
+++ b/apps/web/src/utils/schemaInfo.ts
@@ -23,14 +23,12 @@ export function canShareFromRepoType(repoType: string | null | undefined) {
 
 export function getSchemaInfoDisplay({
   projectId,
-  clientId,
   localVersion,
   mode,
   serverVersion,
   defaultRepoSchemaType,
 }: {
   projectId: string;
-  clientId: string;
   localVersion?: number;
   mode?: string;
   serverVersion?: number;
@@ -49,7 +47,6 @@ export function getSchemaInfoDisplay({
     canShare: canShareFromRepoType(repoType),
     summary: versionBits.length > 0 ? `${repoType} · ${versionBits.join(" · ")}` : repoType,
     projectId,
-    clientId,
     shareHint: canShareFromRepoType(repoType)
       ? undefined
       : "Sharing needs a basic-schema repo. This account is still on the older type.",

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,9 +1,1 @@
 /// <reference types="vite/client" />
-
-interface ImportMetaEnv {
-  readonly VITE_BASIC_CLIENT_ID?: string;
-}
-
-interface ImportMeta {
-  readonly env: ImportMetaEnv;
-}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
`createBasic({ clientId })` now uses the same project DID as the schema:

`did:web:api.basic.tech:projects:701b11bc59a845b581487184d7733e5b`

That DID already publishes `did.json` + `client-metadata.json` on `api.basic.tech`, so it is the only app/project identifier. The profile popup no longer shows a separate `client did:web:tsk.lol` line.

Removed the `VITE_BASIC_CLIENT_ID` override so the id cannot silently drift.

## Note
Published client metadata currently lists only `https://tsk.lol` redirect URIs. Localhost login will fail with `REDIRECT_URI_NOT_REGISTERED` until localhost is added on the project.

## Test plan
- Unit test that `BASIC_CLIENT_ID === PROJECT_ID`
- Profile popup shows one project DID and no `did:web:tsk.lol` client line

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fb9627c-db98-4e4d-84e5-fc1e233d7152?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fb9627c-db98-4e4d-84e5-fc1e233d7152&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

