### PR TITLE
Open received shared tasks in the island and drawer

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@tsk/web",
   "private": true,
-  "version": "7.0.0",
+  "version": "7.0.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { type Dispatch, type SetStateAction, useCallback, useEffect, useState } from "react";
 import bgImage from "/bg2.jpg";
 import "./App.css";
 import AboutModal from "./components/AboutModal";
@@ -19,12 +19,14 @@ import UserAvatarButton from "./components/UserAvatarButton";
 import { ThemeProvider, useTheme } from "./contexts/ThemeContext";
 import { useAppActions } from "./hooks/useAppActions";
 import { useFolderRecords, useScheduleRecords, useTaskRecords } from "./hooks/useBasicData";
+import { useSourcedTaskMutations } from "./hooks/useSourcedTaskMutations";
+import { isSharedTaskSource } from "./utils/taskSource";
 import { useBasicDbReady } from "./hooks/useBasicDbReady";
 import { useHomeKeyboardShortcuts } from "./hooks/useHomeKeyboardShortcuts";
 import { useHomeUiState } from "./hooks/useHomeUiState";
 import { useTaskCollections } from "./hooks/useTaskCollections";
 import { ScheduleCardData } from "./utils/schedule";
-import { Task } from "./utils/types";
+import { Task, TaskSource } from "./utils/types";
 
 function Home() {
   const isDbReady = useBasicDbReady();
@@ -38,7 +40,20 @@ function Home() {
   const [showDelayedLoadingState, setShowDelayedLoadingState] = useState(false);
 
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
+  const [selectedTaskSource, setSelectedTaskSource] = useState<TaskSource | null>(null);
   const [selectedEvent, setSelectedEvent] = useState<ScheduleCardData | null>(null);
+
+  const setSelectedTaskAndClearSource = useCallback<Dispatch<SetStateAction<Task | null>>>((value) => {
+    if (typeof value === "function") {
+      setSelectedTask(value);
+      return;
+    }
+
+    setSelectedTask(value);
+    if (!value) {
+      setSelectedTaskSource(null);
+    }
+  }, []);
 
   const {
     activeFolder,
@@ -133,9 +148,25 @@ function Home() {
     setDrawerOpen,
     setIsNewTaskMode,
     setSelectedEvent,
-    setSelectedTask,
+    setSelectedTask: setSelectedTaskAndClearSource,
     themeLocation: theme.location,
   });
+  const sourcedTaskMutations = useSourcedTaskMutations(selectedTaskSource);
+  const isSharedSelection = isSharedTaskSource(selectedTaskSource);
+  const selectedTaskUpdate = isSharedSelection ? sourcedTaskMutations.updateTask : updateTask;
+  const selectedTaskDelete = useCallback((taskId: string) => {
+    if (isSharedSelection) {
+      sourcedTaskMutations.deleteTask(taskId);
+      if (selectedTask?.id === taskId) {
+        setSelectedTask(null);
+        setSelectedTaskSource(null);
+        setDrawerOpen(false);
+      }
+      return;
+    }
+
+    void deleteTask(taskId);
+  }, [deleteTask, isSharedSelection, selectedTask?.id, setDrawerOpen, sourcedTaskMutations]);
 
   const handleMobileViewChange = useCallback(
     (view: "tasks" | "calendar") => {
@@ -144,6 +175,7 @@ function Home() {
         setDrawerOpen(false);
         setIsNewTaskMode(false);
         setSelectedTask(null);
+        setSelectedTaskSource(null);
         setSelectedEvent(null);
       }
     },
@@ -153,15 +185,17 @@ function Home() {
   const handleEventSelectWrapper = useCallback((event: ScheduleCardData | null) => {
     setSelectedEvent(event);
     setSelectedTask(null);
+    setSelectedTaskSource(null);
   }, []);
 
   const handleTaskSelect = useCallback(
-    (task: Task) => {
+    (task: Task, source?: TaskSource | null) => {
       if (!task.id) {
         return;
       }
 
       setSelectedTask({ ...task });
+      setSelectedTaskSource(source ?? null);
       setSelectedEvent(null);
       setCurrentView("home");
       setIsNewTaskMode(false);
@@ -176,6 +210,9 @@ function Home() {
   const handleTaskSelectWrapper = useCallback((task: Task | null) => {
     setSelectedTask(task);
     setSelectedEvent(null);
+    if (!task) {
+      setSelectedTaskSource(null);
+    }
   }, []);
 
   const handleScheduleCardClick = useCallback(
@@ -185,6 +222,7 @@ function Home() {
       if (isDeletedTask || cardData.type === "task:completed") {
         setSelectedEvent(cardData);
         setSelectedTask(null);
+        setSelectedTaskSource(null);
         setIsNewTaskMode(false);
         if (isMobile) {
           setDrawerOpen(true);
@@ -196,6 +234,7 @@ function Home() {
         const task = tasks.find((item) => item.id === cardData.taskId);
         if (task) {
           setSelectedTask(task);
+          setSelectedTaskSource(null);
           setSelectedEvent(null);
           setIsNewTaskMode(false);
           if (isMobile) {
@@ -208,6 +247,7 @@ function Home() {
       if (cardData.type === "event" || cardData.type === "other") {
         setSelectedEvent(cardData);
         setSelectedTask(null);
+        setSelectedTaskSource(null);
         setIsNewTaskMode(false);
         if (isMobile) {
           setDrawerOpen(true);
@@ -390,6 +430,9 @@ function Home() {
                               viewMode={viewMode}
                               isMobile={isMobile}
                               isDarkMode={theme.isDarkMode}
+                              selectedTaskId={selectedTask?.id}
+                              selectedMountId={selectedTaskSource?.mountId}
+                              onTaskSelect={handleTaskSelect}
                             />
                           ) : null}
 
@@ -614,17 +657,18 @@ function Home() {
                 <DynamicIsland
                   selectedTask={selectedTask}
                   selectedEvent={selectedEvent}
+                  taskSource={selectedTaskSource}
                   onTaskSelect={handleTaskSelectWrapper}
                   onEventSelect={handleEventSelectWrapper}
                   onAddTask={handleAddTask}
                   onAddEvent={handleAddEvent}
-                  onUpdateTask={updateTask}
-                  onDeleteTask={deleteTask}
+                  onUpdateTask={selectedTaskUpdate}
+                  onDeleteTask={selectedTaskDelete}
                   onUpdateEvent={updateScheduleEvent}
                   onDeleteEvent={deleteScheduleEvent}
-                  onAddToSchedule={handleAddToSchedule}
-                  onAddSubtask={handleAddSubtask}
-                  onEnterFocus={handleEnterFocus}
+                  onAddToSchedule={isSharedSelection ? undefined : handleAddToSchedule}
+                  onAddSubtask={isSharedSelection ? undefined : handleAddSubtask}
+                  onEnterFocus={isSharedSelection ? undefined : handleEnterFocus}
                   tasks={tasks}
                   folders={folders}
                   activeFolder={activeFolder}
@@ -646,20 +690,21 @@ function Home() {
                   setIsOpen={setDrawerOpen}
                   task={selectedTask}
                   event={selectedEvent}
-                  updateFunction={updateTask}
-                  deleteTask={deleteTask}
+                  taskSource={selectedTaskSource}
+                  updateFunction={selectedTaskUpdate}
+                  deleteTask={selectedTaskDelete}
                   isNewTaskMode={isNewTaskMode}
                   currentView={mobileView}
                   onAddTask={handleAddTask}
-                  onAddToSchedule={handleAddToSchedule}
+                  onAddToSchedule={isSharedSelection ? undefined : handleAddToSchedule}
                   onUpdateEvent={updateScheduleEvent}
                   onDeleteEvent={deleteScheduleEvent}
                   onAddEvent={handleAddEvent}
-                  onAddSubtask={handleAddSubtask}
-                  onUpdateSubtask={updateTask}
-                  onDeleteSubtask={deleteTask}
+                  onAddSubtask={isSharedSelection ? undefined : handleAddSubtask}
+                  onUpdateSubtask={selectedTaskUpdate}
+                  onDeleteSubtask={selectedTaskDelete}
                   onTaskSelect={handleTaskSelect}
-                  onEnterFocus={handleEnterFocus}
+                  onEnterFocus={isSharedSelection ? undefined : handleEnterFocus}
                   folders={folders}
                 />
               )}

--- a/apps/web/src/components/DynamicIsland.tsx
+++ b/apps/web/src/components/DynamicIsland.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
-import { Folder, Task, TaskUpdate } from '../utils/types';
+import { Folder, Task, TaskSource, TaskUpdate } from '../utils/types';
 import { ScheduleCardData, ScheduleCardInput, ScheduleCardUpdate, getEventDuration, getTimeFromDateTime } from '../utils/schedule';
 import Checkbox from './Checkbox';
 import { useTheme } from '../contexts/ThemeContext';
@@ -12,6 +12,7 @@ import { useAutoResizeTextarea } from '../hooks/useAutoResizeTextarea';
 interface DynamicIslandProps {
   selectedTask: Task | null;
   selectedEvent: ScheduleCardData | null;
+  taskSource?: TaskSource | null;
   onTaskSelect: (task: Task | null) => void;
   onEventSelect: (event: ScheduleCardData | null) => void;
   onAddTask: (taskName: string) => Promise<string | null>;
@@ -40,6 +41,7 @@ interface DynamicIslandProps {
 const DynamicIsland: React.FC<DynamicIslandProps> = ({
   selectedTask,
   selectedEvent,
+  taskSource = null,
   onTaskSelect,
   onEventSelect,
   onAddTask,
@@ -114,12 +116,12 @@ const DynamicIsland: React.FC<DynamicIslandProps> = ({
   const isEventView = selectedEvent !== null;
   
   // Fetch scheduled events for the selected task
-  const liveTask = useTaskRecord(selectedTask?.id);
+  const liveTask = useTaskRecord(selectedTask?.id, taskSource?.mountId);
   const liveEvent = useScheduleRecord(selectedEvent?.id);
   const currentTask = liveTask || selectedTask;
   const currentEvent = liveEvent || selectedEvent;
-  const { events: scheduledEventsForTask } = useScheduleRecords(selectedTask?.id);
-  const scheduledEvents = selectedTask?.id ? scheduledEventsForTask : null;
+  const { events: scheduledEventsForTask } = useScheduleRecords(taskSource ? null : selectedTask?.id);
+  const scheduledEvents = !taskSource && selectedTask?.id ? scheduledEventsForTask : null;
 
   // Check if task has any scheduled events for today
   const hasScheduledEventToday = (() => {
@@ -156,7 +158,10 @@ const DynamicIsland: React.FC<DynamicIslandProps> = ({
       : null;
   const deletedTaskSubtasksResult = useSubtaskRecords(deletedTaskParentId);
   const deletedTaskSubtasks = deletedTaskParentId ? deletedTaskSubtasksResult : null;
-  const subtasks = useSubtaskRecords(selectedTask?.id && !selectedTask?.parentTaskId ? selectedTask.id : null);
+  const subtasks = useSubtaskRecords(
+    selectedTask?.id && !selectedTask?.parentTaskId && !taskSource ? selectedTask.id : null,
+    taskSource?.mountId,
+  );
 
   // Watch for newly created task to appear in tasks list
   useEffect(() => {
@@ -1405,7 +1410,7 @@ const DynamicIsland: React.FC<DynamicIslandProps> = ({
                   style={{ height: 'auto' }}
                 />
 
-                {currentTask?.id ? (
+                {currentTask?.id && !taskSource ? (
                   <TaskSharePanel
                     taskId={currentTask.id}
                     taskName={currentTask.name || title}

--- a/apps/web/src/components/SharedTasksView.tsx
+++ b/apps/web/src/components/SharedTasksView.tsx
@@ -3,16 +3,26 @@ import { basic } from "../basic";
 import { useOpenedMounts } from "../hooks/useOpenedMounts";
 import { unwrapTasks } from "../utils/basicRecords";
 import { shortDid } from "../utils/shares";
-import type { TaskUpdate } from "../utils/types";
+import type { Task, TaskSource, TaskUpdate } from "../utils/types";
 import ListItem from "./ListItem";
 
 interface SharedTasksViewProps {
   viewMode: "compact" | "cozy" | "chonky";
   isMobile: boolean;
   isDarkMode: boolean;
+  selectedTaskId?: string | null;
+  selectedMountId?: string | null;
+  onTaskSelect: (task: Task, source: TaskSource) => void;
 }
 
-export default function SharedTasksView({ viewMode, isMobile, isDarkMode }: SharedTasksViewProps) {
+export default function SharedTasksView({
+  viewMode,
+  isMobile,
+  isDarkMode,
+  selectedTaskId,
+  selectedMountId,
+  onTaskSelect,
+}: SharedTasksViewProps) {
   const { isReady, isSignedIn, isLoading, error, mounts, manageUrl } = useOpenedMounts();
   const { signIn } = basic.useAuth();
 
@@ -83,6 +93,8 @@ export default function SharedTasksView({ viewMode, isMobile, isDarkMode }: Shar
           viewMode={viewMode}
           isMobile={isMobile}
           isDarkMode={isDarkMode}
+          selectedTaskId={selectedMountId === mount.id ? selectedTaskId : null}
+          onTaskSelect={onTaskSelect}
         />
       ))}
     </div>
@@ -96,6 +108,8 @@ function SharedMountTaskList({
   viewMode,
   isMobile,
   isDarkMode,
+  selectedTaskId,
+  onTaskSelect,
 }: {
   mountId: string;
   role: "viewer" | "editor";
@@ -103,6 +117,8 @@ function SharedMountTaskList({
   viewMode: "compact" | "cozy" | "chonky";
   isMobile: boolean;
   isDarkMode: boolean;
+  selectedTaskId?: string | null;
+  onTaskSelect: (task: Task, source: TaskSource) => void;
 }) {
   const { data, isLoading, error } = basic.useQuery("tasks", undefined, { source: { mountId } });
   const tasksTable = basic.useCollection("tasks", { source: { mountId } });
@@ -127,9 +143,8 @@ function SharedMountTaskList({
     void tasksTable.delete(id);
   };
 
-  const handleTaskSelect = () => {
-    // Shared tasks stay in this list for now; opening them in the island
-    // would write back to the local repo.
+  const handleTaskSelect = (task: Task) => {
+    onTaskSelect(task, { mountId, role });
   };
 
   if (isLoading) {
@@ -153,6 +168,7 @@ function SharedMountTaskList({
             updateTask={updateTask}
             deleteTask={deleteTask}
             handleTaskSelect={handleTaskSelect}
+            isSelected={selectedTaskId === task.id}
             viewMode={viewMode}
             isMobile={isMobile}
           />

--- a/apps/web/src/components/SilkTaskDrawer.tsx
+++ b/apps/web/src/components/SilkTaskDrawer.tsx
@@ -11,7 +11,7 @@ import { ScheduleCardData } from '../utils/schedule';
 import { useTheme } from '../contexts/ThemeContext';
 import { useScheduleRecords, useSubtaskRecords, useTaskRecords } from '../hooks/useBasicData';
 import { useModalHistory } from '../hooks/useModalHistory';
-import { Task, Folder } from '../utils/types';
+import { Task, TaskSource, Folder } from '../utils/types';
 import './SilkTaskDrawer.css';
 import './SheetWithKeyboard.css';
 
@@ -20,6 +20,7 @@ interface TaskDrawerProps {
   setIsOpen: (isOpen: boolean) => void;
   task: Task | null;
   event?: ScheduleCardData | null;
+  taskSource?: TaskSource | null;
   updateFunction: (id: string, changes: Partial<Task>) => void;
   deleteTask?: (id: string) => void;
   isNewTaskMode?: boolean;
@@ -42,6 +43,7 @@ export default function SilkTaskDrawer({
   setIsOpen,
   task, 
   event,
+  taskSource = null,
   updateFunction, 
   deleteTask,
   isNewTaskMode = false,
@@ -87,9 +89,9 @@ export default function SilkTaskDrawer({
   
   const { events: allScheduleEvents } = useScheduleRecords();
   const scheduledEvents = useMemo(() => {
-    if (!task?.id) return [];
+    if (taskSource || !task?.id) return [];
     return allScheduleEvents.filter((scheduleEvent) => scheduleEvent.taskId === task.id);
-  }, [task?.id, allScheduleEvents]);
+  }, [task?.id, allScheduleEvents, taskSource]);
 
   const deletedTaskParentId =
     event?.type === 'task' &&
@@ -681,6 +683,7 @@ export default function SilkTaskDrawer({
                     onDeleteSubtask={onDeleteSubtask}
                     onEnterFocus={onEnterFocus}
                     folders={folders}
+                    taskSource={taskSource}
                   />
                 )}
               </div>

--- a/apps/web/src/components/TaskModal.tsx
+++ b/apps/web/src/components/TaskModal.tsx
@@ -1,4 +1,4 @@
-import { Folder, Task, TaskUpdate } from "../utils/types";
+import { Folder, Task, TaskSource, TaskUpdate } from "../utils/types";
 import { useState, useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
 import Checkbox from './Checkbox';
@@ -11,7 +11,7 @@ import { useAutoResizeTextarea } from '../hooks/useAutoResizeTextarea';
 import { showPickerOrClick } from '../utils/showPicker';
 
 export const TaskModal = ({
-  task, updateFunction, inDrawer = false, deleteTask, new: isNew = false, onDelete, onAddToSchedule, scheduledEvents, onUpdateEvent, onDeleteEvent, onAddSubtask, onUpdateSubtask, onDeleteSubtask, onEnterFocus, folders
+  task, updateFunction, inDrawer = false, deleteTask, new: isNew = false, onDelete, onAddToSchedule, scheduledEvents, onUpdateEvent, onDeleteEvent, onAddSubtask, onUpdateSubtask, onDeleteSubtask, onEnterFocus, folders, taskSource = null
 }: {
   task: Task;
   updateFunction: (id: string, changes: TaskUpdate) => void;
@@ -28,6 +28,7 @@ export const TaskModal = ({
   onDeleteSubtask?: (id: string) => void;
   onEnterFocus?: (task: Task) => void;
   folders?: Folder[];
+  taskSource?: TaskSource | null;
 }) => {
   const { theme } = useTheme();
   const { accentColor, isDarkMode } = theme;
@@ -47,7 +48,10 @@ export const TaskModal = ({
   const nameInputRef = useRef<HTMLTextAreaElement | null>(null);
   const descTextareaRef = useRef<HTMLTextAreaElement | null>(null);
   
-  const subtasks = useSubtaskRecords(task?.id && !task?.parentTaskId ? task.id : null);
+  const subtasks = useSubtaskRecords(
+    task?.id && !task?.parentTaskId && !taskSource ? task.id : null,
+    taskSource?.mountId,
+  );
 
   // Check if task has any scheduled events for today
   const hasScheduledEventToday = (() => {
@@ -669,7 +673,7 @@ export const TaskModal = ({
           placeholder="Some description..."
           style={{ height: 'auto' }}
         />
-        {!isNew && task?.id ? (
+        {!isNew && task?.id && !taskSource ? (
           <TaskSharePanel taskId={task.id} taskName={taskName || task.name} />
         ) : null}
         </div>{/* End scrollable content area */}

--- a/apps/web/src/hooks/useBasicData.ts
+++ b/apps/web/src/hooks/useBasicData.ts
@@ -25,8 +25,13 @@ export function useFolderRecords() {
   return { folders, isLoading, error };
 }
 
-export function useTaskRecord(id: string | null | undefined): Task | null {
-  const { tasks } = useTaskRecords();
+export function useTaskRecord(id: string | null | undefined, mountId?: string | null): Task | null {
+  const { data } = basic.useQuery(
+    "tasks",
+    undefined,
+    mountId ? { source: { mountId } } : undefined,
+  );
+  const tasks = useMemo(() => unwrapTasks(data), [data]);
   return useMemo(() => (id ? tasks.find((task) => task.id === id) ?? null : null), [id, tasks]);
 }
 
@@ -35,10 +40,14 @@ export function useScheduleRecord(id: string | null | undefined): ScheduleCardDa
   return useMemo(() => (id ? events.find((event) => event.id === id) ?? null : null), [events, id]);
 }
 
-export function useSubtaskRecords(parentTaskId: string | null | undefined): Task[] {
-  const { data } = basic.useQuery("tasks", {
-    where: { parentTaskId: parentTaskId ?? "" },
-  });
+export function useSubtaskRecords(parentTaskId: string | null | undefined, mountId?: string | null): Task[] {
+  const { data } = basic.useQuery(
+    "tasks",
+    {
+      where: { parentTaskId: parentTaskId ?? "" },
+    },
+    mountId ? { source: { mountId } } : undefined,
+  );
 
   return useMemo(
     () => (parentTaskId ? unwrapTasks(data) : []),

--- a/apps/web/src/hooks/useSourcedTaskMutations.ts
+++ b/apps/web/src/hooks/useSourcedTaskMutations.ts
@@ -1,0 +1,32 @@
+import { useCallback } from "react";
+import { basic } from "../basic";
+import type { TaskSource, TaskUpdate } from "../utils/types";
+
+export function useSourcedTaskMutations(source: TaskSource | null) {
+  const mountId = source?.mountId;
+  const canEdit = !source || source.role === "editor";
+  const tasksTable = basic.useCollection("tasks", mountId ? { source: { mountId } } : undefined);
+
+  const updateTask = useCallback((id: string, changes: TaskUpdate) => {
+    if (!canEdit) {
+      return;
+    }
+
+    void tasksTable.patch(id, changes);
+  }, [canEdit, tasksTable]);
+
+  const deleteTask = useCallback((id: string) => {
+    if (!canEdit) {
+      return;
+    }
+
+    void tasksTable.delete(id);
+  }, [canEdit, tasksTable]);
+
+  return {
+    canEdit,
+    deleteTask,
+    isShared: Boolean(source),
+    updateTask,
+  };
+}

--- a/apps/web/src/utils/taskSource.test.ts
+++ b/apps/web/src/utils/taskSource.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from "vitest";
+import { canEditTaskSource, isSharedTaskSource } from "./taskSource";
+
+describe("isSharedTaskSource", () => {
+  it("is true only for a mount source", () => {
+    expect(isSharedTaskSource(null)).toBe(false);
+    expect(isSharedTaskSource({ mountId: "mnt_1", role: "viewer" })).toBe(true);
+  });
+});
+
+describe("canEditTaskSource", () => {
+  it("allows local tasks and shared editors", () => {
+    expect(canEditTaskSource(null)).toBe(true);
+    expect(canEditTaskSource({ mountId: "mnt_1", role: "editor" })).toBe(true);
+    expect(canEditTaskSource({ mountId: "mnt_1", role: "viewer" })).toBe(false);
+  });
+});

--- a/apps/web/src/utils/taskSource.ts
+++ b/apps/web/src/utils/taskSource.ts
@@ -1,0 +1,9 @@
+import type { TaskSource } from "./types";
+
+export function isSharedTaskSource(source: TaskSource | null | undefined): source is TaskSource {
+  return Boolean(source?.mountId);
+}
+
+export function canEditTaskSource(source: TaskSource | null | undefined) {
+  return !isSharedTaskSource(source) || source.role === "editor";
+}

--- a/apps/web/src/utils/types.ts
+++ b/apps/web/src/utils/types.ts
@@ -14,6 +14,11 @@ export type Task = {
 
 export type TaskUpdate = Partial<Pick<Task, "name" | "description" | "completed" | "parentTaskId" | "labels">>;
 
+export type TaskSource = {
+  mountId: string;
+  role: "viewer" | "editor";
+};
+
 export type Folder = {
   id: string;
   name: string;

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tsk-monorepo",
   "private": true,
-  "version": "7.0.0",
+  "version": "7.0.1",
   "workspaces": [
     "apps/*"
   ],


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
Received shares in the Shared tab now open the same detail UI as owned tasks:

- Desktop: dynamic island
- Mobile: Silk drawer / task modal

Clicks were previously a no-op so the island would not write a shared task into the local repo. Selection now carries a `TaskSource` (`mountId` + role). Reads and edits go through `{ source: { mountId } }`. Owner-only actions (share out, add to today, focus, subtasks) stay hidden on received tasks.

## Test plan
- Unit tests for task-source helpers
- Shared tab: click a received task → island/drawer opens
- Edits on an editor share persist on the mount, not the local task list
- Viewer shares stay read-only

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fb9627c-db98-4e4d-84e5-fc1e233d7152?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fb9627c-db98-4e4d-84e5-fc1e233d7152&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

