### PR TITLE
Upgrade Basic SDK to 0.11.0-beta.2

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,8 +12,8 @@
     "test": "vitest run"
   },
   "dependencies": {
-    "@basictech/react": "0.11.0-beta.1",
-    "@basictech/schema": "0.11.0-beta.1",
+    "@basictech/react": "0.11.0-beta.2",
+    "@basictech/schema": "0.11.0-beta.2",
     "@radix-ui/react-popover": "^1.1.19",
     "@radix-ui/react-switch": "^1.3.3",
     "@silk-hq/components": "^0.8.15",

--- a/apps/web/src/components/TaskSharePanel.tsx
+++ b/apps/web/src/components/TaskSharePanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState, useTransition } from "react";
+import { useMemo, useState, useTransition } from "react";
 import { basic } from "../basic";
 import { useContactHandles } from "../hooks/useContactHandles";
 import { defaultRepoType } from "../utils/schemaInfo";
@@ -27,11 +27,7 @@ export default function TaskSharePanel({ taskId, taskName, compact = false }: Ta
     () => taskShares.map((share) => share.recipientDid),
     [taskShares],
   );
-  const getContactHandle = useCallback(
-    (did: string) => shares.getContactHandle(did),
-    [shares],
-  );
-  const contactHandles = useContactHandles(recipientDids, getContactHandle);
+  const contactHandles = useContactHandles(recipientDids, shares.getContactHandle);
 
   const submitShare = () => {
     setError(null);

--- a/apps/web/src/components/TaskSharePanel.tsx
+++ b/apps/web/src/components/TaskSharePanel.tsx
@@ -1,7 +1,8 @@
-import { useMemo, useState, useTransition } from "react";
+import { useCallback, useMemo, useState, useTransition } from "react";
 import { basic } from "../basic";
+import { useContactHandles } from "../hooks/useContactHandles";
 import { defaultRepoType } from "../utils/schemaInfo";
-import { isOpenShare, resolveShareRecipient, shareErrorMessage, shareIncludesTask, shortDid } from "../utils/shares";
+import { displayShareRecipient, isOpenShare, shareErrorMessage, shareIncludesTask, shareRecipientInput } from "../utils/shares";
 
 interface TaskSharePanelProps {
   taskId: string;
@@ -22,15 +23,23 @@ export default function TaskSharePanel({ taskId, taskName, compact = false }: Ta
     () => shares.outgoingShares.filter((share) => isOpenShare(share) && shareIncludesTask(share, taskId)),
     [shares.outgoingShares, taskId],
   );
+  const recipientDids = useMemo(
+    () => taskShares.map((share) => share.recipientDid),
+    [taskShares],
+  );
+  const getContactHandle = useCallback(
+    (did: string) => shares.getContactHandle(did),
+    [shares],
+  );
+  const contactHandles = useContactHandles(recipientDids, getContactHandle);
 
   const submitShare = () => {
     setError(null);
     startTransition(async () => {
       try {
-        const recipientDid = await resolveShareRecipient(handle);
         await shares.create({
           repo: "default",
-          recipientDid,
+          ...shareRecipientInput(handle),
           role: "editor",
           scope: [{ table: "tasks", recordIds: [taskId] }],
           display: { shareName: taskName },
@@ -115,8 +124,8 @@ export default function TaskSharePanel({ taskId, taskName, compact = false }: Ta
         <ul className="space-y-1">
           {taskShares.map((share) => (
             <li key={share.id} className="flex items-center justify-between gap-2 text-xs opacity-80">
-              <span>
-                {shortDid(share.recipientDid)}
+              <span title={share.recipientDid}>
+                {displayShareRecipient(share.recipientDid, contactHandles[share.recipientDid])}
                 <span className="ml-2 uppercase tracking-wider opacity-60">{share.state}</span>
               </span>
               <button

--- a/apps/web/src/hooks/useContactHandles.test.ts
+++ b/apps/web/src/hooks/useContactHandles.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { mergeContactHandles } from "./useContactHandles";
+
+describe("mergeContactHandles", () => {
+  it("keeps the previous object when nothing changed", () => {
+    const prev = { "did:plc:alice": "alice" };
+    expect(
+      mergeContactHandles(prev, [["did:plc:alice", "alice"]]),
+    ).toBe(prev);
+  });
+
+  it("replaces the object when a handle is added", () => {
+    const prev = { "did:plc:alice": "alice" };
+    const next = mergeContactHandles(prev, [
+      ["did:plc:alice", "alice"],
+      ["did:plc:bob", "bob"],
+    ]);
+    expect(next).toEqual({
+      "did:plc:alice": "alice",
+      "did:plc:bob": "bob",
+    });
+    expect(next).not.toBe(prev);
+  });
+
+  it("replaces the object when a handle changes", () => {
+    const prev = { "did:plc:alice": "alice" };
+    expect(
+      mergeContactHandles(prev, [["did:plc:alice", "alice.basic.id"]]),
+    ).toEqual({
+      "did:plc:alice": "alice.basic.id",
+    });
+  });
+
+  it("ignores null handles", () => {
+    const prev = { "did:plc:alice": "alice" };
+    expect(mergeContactHandles(prev, [["did:plc:bob", null]])).toBe(prev);
+  });
+});

--- a/apps/web/src/hooks/useContactHandles.ts
+++ b/apps/web/src/hooks/useContactHandles.ts
@@ -1,0 +1,42 @@
+import { useEffect, useState } from "react";
+
+export function useContactHandles(
+  dids: string[],
+  getContactHandle: (did: string) => Promise<string | null>,
+) {
+  const [handles, setHandles] = useState<Record<string, string>>({});
+  const didKey = [...new Set(dids.filter(Boolean))].toSorted().join("|");
+
+  useEffect(() => {
+    const unique = didKey ? didKey.split("|") : [];
+    if (unique.length === 0) {
+      return undefined;
+    }
+
+    let cancelled = false;
+
+    void Promise.all(
+      unique.map(async (did) => [did, await getContactHandle(did)] as const),
+    ).then((entries) => {
+      if (cancelled) {
+        return;
+      }
+
+      setHandles((current) => {
+        const next = { ...current };
+        for (const [did, handle] of entries) {
+          if (handle) {
+            next[did] = handle;
+          }
+        }
+        return next;
+      });
+    });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [didKey, getContactHandle]);
+
+  return handles;
+}

--- a/apps/web/src/hooks/useContactHandles.ts
+++ b/apps/web/src/hooks/useContactHandles.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useEffectEvent, useState } from "react";
 
 export function mergeContactHandles(
   current: Record<string, string>,
@@ -21,22 +21,22 @@ export function useContactHandles(
   getContactHandle?: ((did: string) => Promise<string | null>) | null,
 ) {
   const [handles, setHandles] = useState<Record<string, string>>({});
-  const getContactHandleRef = useRef(getContactHandle);
-  getContactHandleRef.current = getContactHandle;
   const didKey = [...new Set(dids.filter(Boolean))].toSorted().join("|");
   const hasLookup = Boolean(getContactHandle);
+  const lookupContactHandle = useEffectEvent(async (did: string) => {
+    return getContactHandle ? getContactHandle(did) : null;
+  });
 
   useEffect(() => {
     const unique = didKey ? didKey.split("|") : [];
-    const lookup = getContactHandleRef.current;
-    if (unique.length === 0 || !lookup) {
+    if (unique.length === 0 || !hasLookup) {
       return undefined;
     }
 
     let cancelled = false;
 
     void Promise.all(
-      unique.map(async (did) => [did, await lookup(did)] as const),
+      unique.map(async (did) => [did, await lookupContactHandle(did)] as const),
     ).then((entries) => {
       if (cancelled) {
         return;

--- a/apps/web/src/hooks/useContactHandles.ts
+++ b/apps/web/src/hooks/useContactHandles.ts
@@ -1,42 +1,54 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
+
+export function mergeContactHandles(
+  current: Record<string, string>,
+  entries: ReadonlyArray<readonly [string, string | null]>,
+) {
+  let changed = false;
+  const next = { ...current };
+  for (const [did, handle] of entries) {
+    if (handle && next[did] !== handle) {
+      next[did] = handle;
+      changed = true;
+    }
+  }
+
+  return changed ? next : current;
+}
 
 export function useContactHandles(
   dids: string[],
-  getContactHandle: (did: string) => Promise<string | null>,
+  getContactHandle?: ((did: string) => Promise<string | null>) | null,
 ) {
   const [handles, setHandles] = useState<Record<string, string>>({});
+  const getContactHandleRef = useRef(getContactHandle);
+  getContactHandleRef.current = getContactHandle;
   const didKey = [...new Set(dids.filter(Boolean))].toSorted().join("|");
+  const hasLookup = Boolean(getContactHandle);
 
   useEffect(() => {
     const unique = didKey ? didKey.split("|") : [];
-    if (unique.length === 0) {
+    const lookup = getContactHandleRef.current;
+    if (unique.length === 0 || !lookup) {
       return undefined;
     }
 
     let cancelled = false;
 
     void Promise.all(
-      unique.map(async (did) => [did, await getContactHandle(did)] as const),
+      unique.map(async (did) => [did, await lookup(did)] as const),
     ).then((entries) => {
       if (cancelled) {
         return;
       }
 
-      setHandles((current) => {
-        const next = { ...current };
-        for (const [did, handle] of entries) {
-          if (handle) {
-            next[did] = handle;
-          }
-        }
-        return next;
-      });
+      setHandles((current) => mergeContactHandles(current, entries));
     });
 
     return () => {
       cancelled = true;
     };
-  }, [didKey, getContactHandle]);
+  }, [didKey, hasLookup]);
 
   return handles;
 }

--- a/apps/web/src/utils/shares.test.ts
+++ b/apps/web/src/utils/shares.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { isOpenShare, normalizeShareHandle, resolveShareRecipient, shareErrorMessage, shareIncludesTask, shortDid } from "./shares";
+import { displayShareRecipient, isOpenShare, normalizeShareHandle, resolveShareRecipient, shareErrorMessage, shareIncludesTask, shareRecipientInput, shortDid } from "./shares";
 
 describe("normalizeShareHandle", () => {
   it("trims, lowercases, and adds .basic.id when needed", () => {
@@ -36,6 +36,31 @@ describe("shortDid", () => {
   it("shortens long DIDs", () => {
     expect(shortDid("did:web:fff.basic.id")).toBe("did:web:fff.basic.id");
     expect(shortDid("did:plc:abcdefghijklmnopqrstuvwxyz")).toBe("did:plc:ab…uvwxyz");
+  });
+});
+
+describe("displayShareRecipient", () => {
+  it("prefers a remembered handle", () => {
+    expect(displayShareRecipient("did:plc:abcdefghijklmnopqrstuvwxyz", "fff.basic.id")).toBe("@fff.basic.id");
+    expect(displayShareRecipient("did:plc:abcdefghijklmnopqrstuvwxyz", "@alice.basic.id")).toBe("@alice.basic.id");
+  });
+
+  it("falls back to a short DID", () => {
+    expect(displayShareRecipient("did:plc:abcdefghijklmnopqrstuvwxyz")).toBe("did:plc:ab…uvwxyz");
+  });
+});
+
+describe("shareRecipientInput", () => {
+  it("keeps a DID as recipientDid", () => {
+    expect(shareRecipientInput("did:web:fff.basic.id")).toEqual({
+      recipientDid: "did:web:fff.basic.id",
+    });
+  });
+
+  it("normalizes a handle for the SDK contact cache", () => {
+    expect(shareRecipientInput("  @FFF  ")).toEqual({
+      recipientHandle: "fff.basic.id",
+    });
   });
 });
 

--- a/apps/web/src/utils/shares.ts
+++ b/apps/web/src/utils/shares.ts
@@ -33,6 +33,28 @@ export function shortDid(did: string) {
   return `${did.slice(0, 10)}…${did.slice(-6)}`;
 }
 
+export function displayShareRecipient(did: string, handle?: string | null) {
+  if (!handle) {
+    return shortDid(did);
+  }
+
+  return handle.startsWith("@") ? handle : `@${handle}`;
+}
+
+export function shareRecipientInput(input: string) {
+  const trimmed = input.trim();
+  if (trimmed.startsWith("did:")) {
+    return { recipientDid: trimmed };
+  }
+
+  const recipientHandle = normalizeShareHandle(trimmed);
+  if (!recipientHandle) {
+    throw new Error("Enter a Basic handle.");
+  }
+
+  return { recipientHandle };
+}
+
 export function shareErrorMessage(error: unknown, repoType?: string | null) {
   const message = error instanceof Error ? error.message : "Could not share this task.";
   const knownType = repoType && repoType !== "unknown" ? repoType : null;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tsk-monorepo",
-  "version": "7.0.0",
+  "version": "7.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tsk-monorepo",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "workspaces": [
         "apps/*"
       ],
@@ -31,10 +31,10 @@
     },
     "apps/web": {
       "name": "@tsk/web",
-      "version": "7.0.0",
+      "version": "7.0.1",
       "dependencies": {
-        "@basictech/react": "^0.11.0-beta.1",
-        "@basictech/schema": "^0.11.0-beta.1",
+        "@basictech/react": "^0.11.0-beta.2",
+        "@basictech/schema": "^0.11.0-beta.2",
         "@radix-ui/react-popover": "^1.1.19",
         "@radix-ui/react-switch": "^1.3.3",
         "@silk-hq/components": "^0.8.15",
@@ -1888,24 +1888,24 @@
       }
     },
     "node_modules/@basictech/core": {
-      "version": "0.11.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@basictech/core/-/core-0.11.0-beta.1.tgz",
-      "integrity": "sha512-TBAZuYFAern975/7AHoZ01VYushNfl1BF3BBav7yGWqr6HxSNxAqZUn5zVYvPdxT7VBNbRwwdIJ859QWNFrp8Q==",
+      "version": "0.11.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@basictech/core/-/core-0.11.0-beta.2.tgz",
+      "integrity": "sha512-HGJFFPJO3MolqU7n9yaSp7NrU3KCu/hk8HdUH4eGSw8X1ZNPqpd9yP3EK3aR4rqfjaEb4DjIqma1t/168HSNCw==",
       "license": "MIT",
       "dependencies": {
-        "@basictech/schema": "0.11.0-beta.1"
+        "@basictech/schema": "0.11.0-beta.2"
       },
       "engines": {
         "node": ">=24.0.0"
       }
     },
     "node_modules/@basictech/react": {
-      "version": "0.11.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@basictech/react/-/react-0.11.0-beta.1.tgz",
-      "integrity": "sha512-Qlx9hhanYbHEDDhs2ka7iCpqk+vcLKVPLXaZJAuF1OxTL/LQsgL98GMAodU7ER07JdXfQR84c7SyAlj/ZDzGtA==",
+      "version": "0.11.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@basictech/react/-/react-0.11.0-beta.2.tgz",
+      "integrity": "sha512-r6bG7RQ6W+a5kzGTYMAmdhEnCgzJewOYWwcbl1atE1xuO2Ey3ALmlb9wW7JBHfcTR73z3vSHkCbylEZkrLcceQ==",
       "license": "MIT",
       "dependencies": {
-        "@basictech/core": "0.11.0-beta.1",
+        "@basictech/core": "0.11.0-beta.2",
         "dexie": "^4.2.1"
       },
       "engines": {
@@ -1916,9 +1916,9 @@
       }
     },
     "node_modules/@basictech/schema": {
-      "version": "0.11.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@basictech/schema/-/schema-0.11.0-beta.1.tgz",
-      "integrity": "sha512-Chkq8GKqR1IS9CrQbwSRCgbPtaJSI+ZROgkVSnt07tHZP6VLFyH0u5MVvqtQiKxrwKYMHUDXgp+Y/DoLDR8HZQ==",
+      "version": "0.11.0-beta.2",
+      "resolved": "https://registry.npmjs.org/@basictech/schema/-/schema-0.11.0-beta.2.tgz",
+      "integrity": "sha512-ffTcixPaGPKt72eG4trX36IXFBwlW9AsTjaNbWpLBiOsgvbKpKvhBKgjjTYGI8hpnw2pZW1TsLNKxk0/bazoTw==",
       "license": "MIT",
       "dependencies": {
         "ajv": "^8.17.1",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What
Install `@basictech/react` and `@basictech/schema` `0.11.0-beta.2` (published Aug 19). `@basictech/core` comes along as `0.11.0-beta.2`.

## Notable SDK changes vs beta.1
- Lifecycle reconcile on focus / online / visibility (no reload after a suspended tab)
- Token refresh retries instead of signing out on transient failures
- Handle resolution for shares uses `defaultPds` (`pds.basic.id`) instead of `identityOrigin`
- `getContactHandle(did)` remembers handle-based share recipients
- Sync session `repair()` / pending repair
- `reconcileTrigger` config for custom hosts
- Schema drift check can take `clientId`

## Test plan
- Unit tests, lint, production build
- Sign in / resume a backgrounded tab
- Create a handle-based share and confirm it still works

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7fb9627c-db98-4e4d-84e5-fc1e233d7152?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7fb9627c-db98-4e4d-84e5-fc1e233d7152&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

